### PR TITLE
Consolidate duplicate section heading styles

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -208,7 +208,7 @@
     line-height: 1.2;
     vertical-align: super
     }
-.calibre24 {
+.section-heading {
     display: block;
     font-size: 0.775em;
     font-weight: bold;
@@ -893,18 +893,6 @@
     border-bottom: currentColor solid 1pt;
     border-left: currentColor none medium;
     padding: 0 5.4pt
-    }
-.calibre109 {
-    display: block;
-    font-size: 0.775em;
-    font-weight: bold;
-    line-height: 1.2;
-    page-break-after: avoid;
-    text-autospace: none;
-    text-decoration: underline;
-    text-indent: 0;
-    text-transform: uppercase;
-    margin: 12pt 0
     }
 .calibre110 {
     border-collapse: separate;

--- a/text/part0000_split_006.html
+++ b/text/part0000_split_006.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection1">
-<h2 class="calibre24" id="calibre_pb_12"><a class="pcalibre pcalibre1" id="_Toc425418798"></a><a class="pcalibre pcalibre1" id="_Toc425418650"></a><a class="pcalibre pcalibre1" id="_Toc425418502"><span class="calibre25">PURPOSE</span></a></h2>
+<h2 class="section-heading" id="calibre_pb_12"><a class="pcalibre pcalibre1" id="_Toc425418798"></a><a class="pcalibre pcalibre1" id="_Toc425418650"></a><a class="pcalibre pcalibre1" id="_Toc425418502"><span class="calibre25">PURPOSE</span></a></h2>
 
 <p class="msonormal1">The EOB New Testament was prepared for personal study and
 liturgical use in English-speaking Orthodox Christian communities. Its format

--- a/text/part0000_split_007.html
+++ b/text/part0000_split_007.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection2">
-<h2 class="calibre24" id="calibre_pb_13"><a class="pcalibre pcalibre1" id="_Toc425418799"></a><a class="pcalibre pcalibre1" id="_Toc425418651"></a><a class="pcalibre pcalibre1" id="_Toc425418503">EOB FOOTNOTES</a></h2>
+<h2 class="section-heading" id="calibre_pb_13"><a class="pcalibre pcalibre1" id="_Toc425418799"></a><a class="pcalibre pcalibre1" id="_Toc425418651"></a><a class="pcalibre pcalibre1" id="_Toc425418503">EOB FOOTNOTES</a></h2>
 
 <p class="msonormal1">Unlike the <b class="calibre7">Orthodox Study Bible (OSB)</b>, the EOB
 footnotes focus on textual and translation issues, and refrain from providing

--- a/text/part0000_split_008.html
+++ b/text/part0000_split_008.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection2">
-<h2 class="calibre24" id="calibre_pb_14"><a class="pcalibre pcalibre1" id="_Toc425418800"></a><a class="pcalibre pcalibre1" id="_Toc425418652"></a><a class="pcalibre pcalibre1" id="_Toc425418504">PRIMARY GREEK TEXT(S)</a></h2>
+<h2 class="section-heading" id="calibre_pb_14"><a class="pcalibre pcalibre1" id="_Toc425418800"></a><a class="pcalibre pcalibre1" id="_Toc425418652"></a><a class="pcalibre pcalibre1" id="_Toc425418504">PRIMARY GREEK TEXT(S)</a></h2>
 
 <p class="msonormal1">The translation of the New Testament included in the EOB is
 based on the official Greek text published by the Ecumenical Patriarchate of

--- a/text/part0000_split_009.html
+++ b/text/part0000_split_009.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection2">
-<h2 class="calibre24" id="calibre_pb_15"><a class="pcalibre pcalibre1" id="_Toc425418801"></a><a class="pcalibre pcalibre1" id="_Toc425418653"></a><a class="pcalibre pcalibre1" id="_Toc425418505">UNDERSTANDING TEXTS AND VARIANTS</a></h2>
+<h2 class="section-heading" id="calibre_pb_15"><a class="pcalibre pcalibre1" id="_Toc425418801"></a><a class="pcalibre pcalibre1" id="_Toc425418653"></a><a class="pcalibre pcalibre1" id="_Toc425418505">UNDERSTANDING TEXTS AND VARIANTS</a></h2>
 
 <p class="msonormal1">Most scholars recognize the existence of four families of
 New Testament manuscripts: <b class="calibre7">Byzantine, Alexandrian, Western and Caesarean</b>.

--- a/text/part0000_split_010.html
+++ b/text/part0000_split_010.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection2">
-<h2 class="calibre24" id="calibre_pb_16"><a class="pcalibre pcalibre1" id="_Toc425418802"></a><a class="pcalibre pcalibre1" id="_Toc425418654"></a><a class="pcalibre pcalibre1" id="_Toc425418506">FOUNDATIONAL ENGLISH TEXT</a></h2>
+<h2 class="section-heading" id="calibre_pb_16"><a class="pcalibre pcalibre1" id="_Toc425418802"></a><a class="pcalibre pcalibre1" id="_Toc425418654"></a><a class="pcalibre pcalibre1" id="_Toc425418506">FOUNDATIONAL ENGLISH TEXT</a></h2>
 
 <p class="msonormal1">The EOB/NT project began as a revision of the WEB (<b class="calibre7">World
 English Bible</b>) which is a fairly accurate, easy-to-read and well-respected

--- a/text/part0000_split_011.html
+++ b/text/part0000_split_011.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection2">
-<h2 class="calibre24" id="calibre_pb_17"><a class="pcalibre pcalibre1" id="_Toc425418803"></a><a class="pcalibre pcalibre1" id="_Toc425418655"></a><a class="pcalibre pcalibre1" id="_Toc425418507">CHURCH OFFICES</a></h2>
+<h2 class="section-heading" id="calibre_pb_17"><a class="pcalibre pcalibre1" id="_Toc425418803"></a><a class="pcalibre pcalibre1" id="_Toc425418655"></a><a class="pcalibre pcalibre1" id="_Toc425418507">CHURCH OFFICES</a></h2>
 
 <p class="msonormal1">The Greek words <span>dia,konoj</span>
 (<i class="calibre4">diakonos</i>), <span>presbu,teroj </span>(<i class="calibre4">presbyteros</i>)

--- a/text/part0000_split_012.html
+++ b/text/part0000_split_012.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection2">
-<h2 class="calibre24" id="calibre_pb_18"><a class="pcalibre pcalibre1" id="_Toc425418804"></a><a class="pcalibre pcalibre1" id="_Toc425418656"></a><a class="pcalibre pcalibre1" id="_Toc425418508">TEMPLE AND SANCTUARY</a></h2>
+<h2 class="section-heading" id="calibre_pb_18"><a class="pcalibre pcalibre1" id="_Toc425418804"></a><a class="pcalibre pcalibre1" id="_Toc425418656"></a><a class="pcalibre pcalibre1" id="_Toc425418508">TEMPLE AND SANCTUARY</a></h2>
 
 <p class="msonormal1">Most translations fail to properly distinguish between <span>i`ero.n</span> (<i class="calibre4">hieron</i>) and <span>nao.j</span> (<i class="calibre4">naos</i>) which are both
 rendered as “temple.” In the context of both heavenly and Jewish Temple

--- a/text/part0000_split_013.html
+++ b/text/part0000_split_013.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection2">
-<h2 class="calibre24" id="calibre_pb_19"><a class="pcalibre pcalibre1" id="_Toc425418805"></a><a class="pcalibre pcalibre1" id="_Toc425418657"></a><a class="pcalibre pcalibre1" id="_Toc425418509">HELL AND HADES</a></h2>
+<h2 class="section-heading" id="calibre_pb_19"><a class="pcalibre pcalibre1" id="_Toc425418805"></a><a class="pcalibre pcalibre1" id="_Toc425418657"></a><a class="pcalibre pcalibre1" id="_Toc425418509">HELL AND HADES</a></h2>
 
 <p class="msonormal1">The King James Version caused lasting confusion by
 translating both Greek words <span>a[|dou</span>

--- a/text/part0000_split_014.html
+++ b/text/part0000_split_014.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection2">
-<h2 class="calibre24" id="calibre_pb_20"><a class="pcalibre pcalibre1" id="_Toc425418806"></a><a class="pcalibre pcalibre1" id="_Toc425418658"></a><a class="pcalibre pcalibre1" id="_Toc425418510">WORSHIP AND DIVINE SERVICE</a></h2>
+<h2 class="section-heading" id="calibre_pb_20"><a class="pcalibre pcalibre1" id="_Toc425418806"></a><a class="pcalibre pcalibre1" id="_Toc425418658"></a><a class="pcalibre pcalibre1" id="_Toc425418510">WORSHIP AND DIVINE SERVICE</a></h2>
 
 <p class="msonormal1">In modern English, “worship” (like prayer) has mainly taken
 on the meaning of an act (invocation, prostration) offered exclusively to God.

--- a/text/part0000_split_015.html
+++ b/text/part0000_split_015.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection2">
-<h2 class="calibre24" id="calibre_pb_21"><a class="pcalibre pcalibre1" id="_Toc425418807"></a><a class="pcalibre pcalibre1" id="_Toc425418659"></a><a class="pcalibre pcalibre1" id="_Toc425418511">KINGDOM</a></h2>
+<h2 class="section-heading" id="calibre_pb_21"><a class="pcalibre pcalibre1" id="_Toc425418807"></a><a class="pcalibre pcalibre1" id="_Toc425418659"></a><a class="pcalibre pcalibre1" id="_Toc425418511">KINGDOM</a></h2>
 
 <p class="msonormal1">It is normative to translate the Greek expression <span>basilei,a tou/ qeou/</span> as “Kingdom of
 God,” although some scholars have also noted that such a translation is

--- a/text/part0000_split_016.html
+++ b/text/part0000_split_016.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection2">
-<h2 class="calibre24" id="calibre_pb_22"><a class="pcalibre pcalibre1" id="_Toc425418808"></a><a class="pcalibre pcalibre1" id="_Toc425418660"></a><a class="pcalibre pcalibre1" id="_Toc425418512">PRONOUNS</a></h2>
+<h2 class="section-heading" id="calibre_pb_22"><a class="pcalibre pcalibre1" id="_Toc425418808"></a><a class="pcalibre pcalibre1" id="_Toc425418660"></a><a class="pcalibre pcalibre1" id="_Toc425418512">PRONOUNS</a></h2>
 
 <p class="msonormal1">New Testament Greek can be confusing if subjects and pronouns
 are translated literally, as in “He said to him.” The EOB/NT often replaces

--- a/text/part0000_split_017.html
+++ b/text/part0000_split_017.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection2">
-<h2 class="calibre24" id="calibre_pb_23"><a class="pcalibre pcalibre1" id="_Toc425418809"></a><a class="pcalibre pcalibre1" id="_Toc425418661"></a><a class="pcalibre pcalibre1" id="_Toc425418513">PROPER NOUNS</a></h2>
+<h2 class="section-heading" id="calibre_pb_23"><a class="pcalibre pcalibre1" id="_Toc425418809"></a><a class="pcalibre pcalibre1" id="_Toc425418661"></a><a class="pcalibre pcalibre1" id="_Toc425418513">PROPER NOUNS</a></h2>
 
 <p class="msonormal1">Hebrew names follow the now usual Masoretic style, except
 for “Elias/Elijah,” “Isaias/Isaiah” and “Zacharias/Zachariah” which are

--- a/text/part0000_split_018.html
+++ b/text/part0000_split_018.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection2">
-<h2 class="calibre24" id="calibre_pb_24"><a class="pcalibre pcalibre1" id="_Toc425418810"></a><a class="pcalibre pcalibre1" id="_Toc425418662"></a><a class="pcalibre pcalibre1" id="_Toc425418514">GENDER FORMS</a></h2>
+<h2 class="section-heading" id="calibre_pb_24"><a class="pcalibre pcalibre1" id="_Toc425418810"></a><a class="pcalibre pcalibre1" id="_Toc425418662"></a><a class="pcalibre pcalibre1" id="_Toc425418514">GENDER FORMS</a></h2>
 
 <p class="msonormal1">Many recent translations have gone to great length to
 introduce questionable translation techniques in order to avoid any reference

--- a/text/part0000_split_019.html
+++ b/text/part0000_split_019.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection2">
-<h2 class="calibre24" id="calibre_pb_25"><a class="pcalibre pcalibre1" id="_Toc425418811"></a><a class="pcalibre pcalibre1" id="_Toc425418663"></a><a class="pcalibre pcalibre1" id="_Toc425418515"><span class="calibre25">CAPITALIZATIONS</span></a><span class="calibre25"> </span></h2>
+<h2 class="section-heading" id="calibre_pb_25"><a class="pcalibre pcalibre1" id="_Toc425418811"></a><a class="pcalibre pcalibre1" id="_Toc425418663"></a><a class="pcalibre pcalibre1" id="_Toc425418515"><span class="calibre25">CAPITALIZATIONS</span></a><span class="calibre25"> </span></h2>
 
 <p class="msonormal1">Greek manuscripts do not have any capitalization. Hence, the
 introduction of capitalized forms is arbitrary and should be clarified.</p>

--- a/text/part0000_split_020.html
+++ b/text/part0000_split_020.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection2">
-<h2 class="calibre24" id="calibre_pb_26"><a class="pcalibre pcalibre1" id="_Toc425418812"></a><a class="pcalibre pcalibre1" id="_Toc425418664"></a><a class="pcalibre pcalibre1" id="_Toc425418516">SPIRIT</a><a title="" href="part0000_split_124.html#_edn22" class="pcalibre pcalibre1" id="_ednref22"><span class="msoendnotereference"><span class="msoendnotereference"><b class="calibre7"><span class="calibre34"><span class="calibre60">[22]</span></span></b></span></span></a></h2>
+<h2 class="section-heading" id="calibre_pb_26"><a class="pcalibre pcalibre1" id="_Toc425418812"></a><a class="pcalibre pcalibre1" id="_Toc425418664"></a><a class="pcalibre pcalibre1" id="_Toc425418516">SPIRIT</a><a title="" href="part0000_split_124.html#_edn22" class="pcalibre pcalibre1" id="_ednref22"><span class="msoendnotereference"><span class="msoendnotereference"><b class="calibre7"><span class="calibre34"><span class="calibre60">[22]</span></span></b></span></span></a></h2>
 
 <p class="msonormal1">The English word “spirit” (or “Spirit”) normally translates
 the Greek <span>pneu/ma</span> (<i class="calibre4">pnevma</i>)

--- a/text/part0000_split_021.html
+++ b/text/part0000_split_021.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection2">
-<h2 class="calibre24" id="calibre_pb_27"><a class="pcalibre pcalibre1" id="_Toc425418813"></a><a class="pcalibre pcalibre1" id="_Toc425418665"></a><a class="pcalibre pcalibre1" id="_Toc425418517"><span class="calibre25">THE ENGLISH PUNCTUATION</span></a></h2>
+<h2 class="section-heading" id="calibre_pb_27"><a class="pcalibre pcalibre1" id="_Toc425418813"></a><a class="pcalibre pcalibre1" id="_Toc425418665"></a><a class="pcalibre pcalibre1" id="_Toc425418517"><span class="calibre25">THE ENGLISH PUNCTUATION</span></a></h2>
 
 <p class="msonormal1">The punctuation approach followed in the EOB/NT may seem
 inconsistent and at odds with strict rules. The reason for this approach is to

--- a/text/part0000_split_022.html
+++ b/text/part0000_split_022.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection2">
-<h2 class="calibre24" id="calibre_pb_28"><a class="pcalibre pcalibre1" id="_Toc425418814"></a><a class="pcalibre pcalibre1" id="_Toc425418666"></a><a class="pcalibre pcalibre1" id="_Toc425418518">AMEN, AMEN</a></h2>
+<h2 class="section-heading" id="calibre_pb_28"><a class="pcalibre pcalibre1" id="_Toc425418814"></a><a class="pcalibre pcalibre1" id="_Toc425418666"></a><a class="pcalibre pcalibre1" id="_Toc425418518">AMEN, AMEN</a></h2>
 
 <p class="msonormal1">After due consideration, it was decided that the Lord’s form
 of emphatic introduction, either “Amen” or “Amen, Amen,” should be transliterated

--- a/text/part0000_split_024.html
+++ b/text/part0000_split_024.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection3">
-<h2 class="calibre24" id="calibre_pb_33"><a class="pcalibre pcalibre1" id="_Toc425418816"></a><a class="pcalibre pcalibre1" id="_Toc425418668"></a><a class="pcalibre pcalibre1" id="_Toc425418520">MATTHEW</a></h2>
+<h2 class="section-heading" id="calibre_pb_33"><a class="pcalibre pcalibre1" id="_Toc425418816"></a><a class="pcalibre pcalibre1" id="_Toc425418668"></a><a class="pcalibre pcalibre1" id="_Toc425418520">MATTHEW</a></h2>
 
 <p class="msonormal1"><b class="calibre7">Authorship/Date</b></p>
 

--- a/text/part0000_split_025.html
+++ b/text/part0000_split_025.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection3">
-<h2 class="calibre24" id="calibre_pb_34"><a class="pcalibre pcalibre1" id="_Toc425418817"></a><a class="pcalibre pcalibre1" id="_Toc425418669"></a><a class="pcalibre pcalibre1" id="_Toc425418521">MARK</a></h2>
+<h2 class="section-heading" id="calibre_pb_34"><a class="pcalibre pcalibre1" id="_Toc425418817"></a><a class="pcalibre pcalibre1" id="_Toc425418669"></a><a class="pcalibre pcalibre1" id="_Toc425418521">MARK</a></h2>
 
 <p class="msonormal1"><b class="calibre7">Authorship/Date</b></p>
 

--- a/text/part0000_split_026.html
+++ b/text/part0000_split_026.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection3">
-<h2 class="calibre24" id="calibre_pb_35"><a class="pcalibre pcalibre1" id="_Toc425418818"></a><a class="pcalibre pcalibre1" id="_Toc425418670"></a><a class="pcalibre pcalibre1" id="_Toc425418522">LUKE AND ACTS</a></h2>
+<h2 class="section-heading" id="calibre_pb_35"><a class="pcalibre pcalibre1" id="_Toc425418818"></a><a class="pcalibre pcalibre1" id="_Toc425418670"></a><a class="pcalibre pcalibre1" id="_Toc425418522">LUKE AND ACTS</a></h2>
 
 <p class="msonormal1"><b class="calibre7">Authorship/Date</b></p>
 

--- a/text/part0000_split_033.html
+++ b/text/part0000_split_033.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection7">
-<h2 class="calibre24" id="calibre_pb_52"><a class="pcalibre pcalibre1" id="_Toc425418823"></a><a class="pcalibre pcalibre1" id="_Toc425418676"></a><a class="pcalibre pcalibre1" id="_Toc425418528">AUTHORSHIP AND DATE</a></h2>
+<h2 class="section-heading" id="calibre_pb_52"><a class="pcalibre pcalibre1" id="_Toc425418823"></a><a class="pcalibre pcalibre1" id="_Toc425418676"></a><a class="pcalibre pcalibre1" id="_Toc425418528">AUTHORSHIP AND DATE</a></h2>
 
 <p class="msonormal1"><span class="calibre67">The Gospel itself is
 anonymous but the author is identified as “the disciple whom Jesus loved”

--- a/text/part0000_split_034.html
+++ b/text/part0000_split_034.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection7">
-<h2 class="calibre24" id="calibre_pb_53"><a class="pcalibre pcalibre1" id="_Toc425418824"></a><a class="pcalibre pcalibre1" id="_Toc425418677"></a><a class="pcalibre pcalibre1" id="_Toc425418529">THEME(S)</a></h2>
+<h2 class="section-heading" id="calibre_pb_53"><a class="pcalibre pcalibre1" id="_Toc425418824"></a><a class="pcalibre pcalibre1" id="_Toc425418677"></a><a class="pcalibre pcalibre1" id="_Toc425418529">THEME(S)</a></h2>
 
 <h3 class="calibre80"><a class="pcalibre pcalibre1" id="_Toc425418678"></a><a class="pcalibre pcalibre1" id="_Toc425418530">The High Priestly
 Gospel</a></h3>

--- a/text/part0000_split_038.html
+++ b/text/part0000_split_038.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection8">
-<h2 class="calibre24" id="calibre_pb_62"><a class="pcalibre pcalibre1" id="_Toc425418828"></a><a class="pcalibre pcalibre1" id="_Toc425418685"></a><a class="pcalibre pcalibre1" id="_Toc425418537">AUTHORSHIP AND DATES</a></h2>
+<h2 class="section-heading" id="calibre_pb_62"><a class="pcalibre pcalibre1" id="_Toc425418828"></a><a class="pcalibre pcalibre1" id="_Toc425418685"></a><a class="pcalibre pcalibre1" id="_Toc425418537">AUTHORSHIP AND DATES</a></h2>
 
 <p class="msonormal1">Orthodox tradition affirms the Pauline authorship of all the
 letters and writings ascribed to the great missionary apostle. It also

--- a/text/part0000_split_039.html
+++ b/text/part0000_split_039.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection8">
-<h2 class="calibre24" id="calibre_pb_63"><a class="pcalibre pcalibre1" id="_Toc425418829"></a><a class="pcalibre pcalibre1" id="_Toc425418686"></a><a class="pcalibre pcalibre1" id="_Toc425418538">THEME</a></h2>
+<h2 class="section-heading" id="calibre_pb_63"><a class="pcalibre pcalibre1" id="_Toc425418829"></a><a class="pcalibre pcalibre1" id="_Toc425418686"></a><a class="pcalibre pcalibre1" id="_Toc425418538">THEME</a></h2>
 
 <p class="msonormal1">As he addresses a large number of practical issues and
 theological themes, Saint Paul remains remarkably consistent. The following

--- a/text/part0000_split_040.html
+++ b/text/part0000_split_040.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection8">
-<h2 class="calibre24" id="calibre_pb_64"><a class="pcalibre pcalibre1" id="_Toc425418830"></a><a class="pcalibre pcalibre1" id="_Toc425418687"></a><a class="pcalibre pcalibre1" id="_Toc425418539">TRANSLATION NOTE FOR ROMANS</a></h2>
+<h2 class="section-heading" id="calibre_pb_64"><a class="pcalibre pcalibre1" id="_Toc425418830"></a><a class="pcalibre pcalibre1" id="_Toc425418687"></a><a class="pcalibre pcalibre1" id="_Toc425418539">TRANSLATION NOTE FOR ROMANS</a></h2>
 
 <p class="msonormal1">In this complex theological masterpiece, St. Paul often used
 the Greek word <span>ga.r</span> to

--- a/text/part0000_split_056.html
+++ b/text/part0000_split_056.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection23">
-<h2 class="calibre24" id="calibre_pb_97"><a class="pcalibre pcalibre1" id="_Toc425418846"></a><a class="pcalibre pcalibre1" id="_Toc425418703"></a><a class="pcalibre pcalibre1" id="_Toc425418555">THE EPISTLE OF JAMES</a></h2>
+<h2 class="section-heading" id="calibre_pb_97"><a class="pcalibre pcalibre1" id="_Toc425418846"></a><a class="pcalibre pcalibre1" id="_Toc425418703"></a><a class="pcalibre pcalibre1" id="_Toc425418555">THE EPISTLE OF JAMES</a></h2>
 
 <p class="msonormal1"><b class="calibre7">Authorship/Date</b></p>
 

--- a/text/part0000_split_057.html
+++ b/text/part0000_split_057.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection23">
-<h2 class="calibre24" id="calibre_pb_98"><a class="pcalibre pcalibre1" id="_Toc425418847"></a><a class="pcalibre pcalibre1" id="_Toc425418704"></a><a class="pcalibre pcalibre1" id="_Toc425418556">THE EPISTLES OF JOHN</a></h2>
+<h2 class="section-heading" id="calibre_pb_98"><a class="pcalibre pcalibre1" id="_Toc425418847"></a><a class="pcalibre pcalibre1" id="_Toc425418704"></a><a class="pcalibre pcalibre1" id="_Toc425418556">THE EPISTLES OF JOHN</a></h2>
 
 <p class="msonormal1"><b class="calibre7">Authorship/Dates</b></p>
 

--- a/text/part0000_split_058.html
+++ b/text/part0000_split_058.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection23">
-<h2 class="calibre24" id="calibre_pb_99"><a class="pcalibre pcalibre1" id="_Toc425418848"></a><a class="pcalibre pcalibre1" id="_Toc425418705"></a><a class="pcalibre pcalibre1" id="_Toc425418557">THE PETRINE EPISTLES, THE EPISTLE OF JUDE</a></h2>
+<h2 class="section-heading" id="calibre_pb_99"><a class="pcalibre pcalibre1" id="_Toc425418848"></a><a class="pcalibre pcalibre1" id="_Toc425418705"></a><a class="pcalibre pcalibre1" id="_Toc425418557">THE PETRINE EPISTLES, THE EPISTLE OF JUDE</a></h2>
 
 <p class="msonormal1"><b class="calibre7">Authorship/Dates</b></p>
 

--- a/text/part0000_split_067.html
+++ b/text/part0000_split_067.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection31">
-<h2 class="calibre24" id="calibre_pb_122"><a class="pcalibre pcalibre1" id="_Toc425418857"></a><a class="pcalibre pcalibre1" id="_Toc425418714"></a><a class="pcalibre pcalibre1" id="_Toc425418566">AUTHORSHIP AND DATE</a></h2>
+<h2 class="section-heading" id="calibre_pb_122"><a class="pcalibre pcalibre1" id="_Toc425418857"></a><a class="pcalibre pcalibre1" id="_Toc425418714"></a><a class="pcalibre pcalibre1" id="_Toc425418566">AUTHORSHIP AND DATE</a></h2>
 
 <p class="msonormal1">Unlike the Gospel, the book of Revelation or Apocalypse
 mentions the name of its author, “John” (1:1, 4, 9; 22:8). However, the exact

--- a/text/part0000_split_068.html
+++ b/text/part0000_split_068.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection31">
-<h2 class="calibre24" id="calibre_pb_123"><a class="pcalibre pcalibre1" id="_Toc425418858"></a><a class="pcalibre pcalibre1" id="_Toc425418715"></a><a class="pcalibre pcalibre1" id="_Toc425418567">FURTHER DISCUSSION OF REVELATION’S DATE</a><a title="" href="part0000_split_127.html#_edn2408" class="pcalibre pcalibre1" id="_ednref2408"><span class="msoendnotereference"><span class="msoendnotereference"><b class="calibre7"><span class="calibre34"><span class="calibre60">[2408]</span></span></b></span></span></a></h2>
+<h2 class="section-heading" id="calibre_pb_123"><a class="pcalibre pcalibre1" id="_Toc425418858"></a><a class="pcalibre pcalibre1" id="_Toc425418715"></a><a class="pcalibre pcalibre1" id="_Toc425418567">FURTHER DISCUSSION OF REVELATION’S DATE</a><a title="" href="part0000_split_127.html#_edn2408" class="pcalibre pcalibre1" id="_ednref2408"><span class="msoendnotereference"><span class="msoendnotereference"><b class="calibre7"><span class="calibre34"><span class="calibre60">[2408]</span></span></b></span></span></a></h2>
 
 <p class="msonormal1">Based on some statements by early writers such as Irenaeus,
 Victorinus, and Eusebius, many commentators have concluded that there is a

--- a/text/part0000_split_069.html
+++ b/text/part0000_split_069.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection31">
-<h2 class="calibre24" id="calibre_pb_124"><a class="pcalibre pcalibre1" id="_Toc425418859"></a><a class="pcalibre pcalibre1" id="_Toc425418716"></a><a class="pcalibre pcalibre1" id="_Toc425418568">THEME(S)</a></h2>
+<h2 class="section-heading" id="calibre_pb_124"><a class="pcalibre pcalibre1" id="_Toc425418859"></a><a class="pcalibre pcalibre1" id="_Toc425418716"></a><a class="pcalibre pcalibre1" id="_Toc425418568">THEME(S)</a></h2>
 
 <p class="msonormal1"><span class="calibre91">Revelation is a fitting
 conclusion to the inspired Holy Scriptures. Genesis is recapitulated and

--- a/text/part0000_split_070.html
+++ b/text/part0000_split_070.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection31">
-<h2 class="calibre24" id="calibre_pb_125"><a class="pcalibre pcalibre1" id="_Toc425418860"></a><a class="pcalibre pcalibre1" id="_Toc425418717"></a><a class="pcalibre pcalibre1" id="_Toc425418569">BABYLON THE GREAT</a></h2>
+<h2 class="section-heading" id="calibre_pb_125"><a class="pcalibre pcalibre1" id="_Toc425418860"></a><a class="pcalibre pcalibre1" id="_Toc425418717"></a><a class="pcalibre pcalibre1" id="_Toc425418569">BABYLON THE GREAT</a></h2>
 
 <p class="msonormal1">Unlike most annotated versions, the EOB footnotes lean
 toward the view that Babylon the Great is in fact apostate Jerusalem, not Rome.

--- a/text/part0000_split_071.html
+++ b/text/part0000_split_071.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection31">
-<h2 class="calibre24" id="calibre_pb_126"><a class="pcalibre pcalibre1" id="_Toc425418861"></a><a class="pcalibre pcalibre1" id="_Toc425418718"></a><a class="pcalibre pcalibre1" id="_Toc425418570">SIGNS BEFORE 70 AD</a></h2>
+<h2 class="section-heading" id="calibre_pb_126"><a class="pcalibre pcalibre1" id="_Toc425418861"></a><a class="pcalibre pcalibre1" id="_Toc425418718"></a><a class="pcalibre pcalibre1" id="_Toc425418570">SIGNS BEFORE 70 AD</a></h2>
 
 <p class="msonormal1">If it is the destruction of Jerusalem that is envisioned in
 Revelation, the following primary sources are of interest to be aware of the

--- a/text/part0000_split_072.html
+++ b/text/part0000_split_072.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection31">
-<h2 class="calibre24" id="calibre_pb_127"><a class="pcalibre pcalibre1" id="_Toc425418862"></a><a class="pcalibre pcalibre1" id="_Toc425418719"></a><a class="pcalibre pcalibre1" id="_Toc425418571">MYSTICAL PATTERNS</a></h2>
+<h2 class="section-heading" id="calibre_pb_127"><a class="pcalibre pcalibre1" id="_Toc425418862"></a><a class="pcalibre pcalibre1" id="_Toc425418719"></a><a class="pcalibre pcalibre1" id="_Toc425418571">MYSTICAL PATTERNS</a></h2>
 
 <p class="msonormal1">In Revelation as in the Gospel of John, the patterns of the
 Old Testament are continued and fulfilled. As in the days of Moses, God’s

--- a/text/part0000_split_075.html
+++ b/text/part0000_split_075.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection33">
-<h2 class="calibre24" id="calibre_pb_136"><a class="pcalibre pcalibre1" id="_Toc425418865"></a><a class="pcalibre pcalibre1" id="_Toc425418722"></a><a class="pcalibre pcalibre1" id="_Toc425418574">Introduction</a></h2>
+<h2 class="section-heading" id="calibre_pb_136"><a class="pcalibre pcalibre1" id="_Toc425418865"></a><a class="pcalibre pcalibre1" id="_Toc425418722"></a><a class="pcalibre pcalibre1" id="_Toc425418574">Introduction</a></h2>
 
 <p class="msonormal1">The position of historic orthodox catholic Christianity on
 the monarchical episcopate is that the three-fold office of bishop, presbyter,

--- a/text/part0000_split_076.html
+++ b/text/part0000_split_076.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection33">
-<h2 class="calibre24" id="calibre_pb_137"><a class="pcalibre pcalibre1" id="_Toc425418866"></a><a class="pcalibre pcalibre1" id="_Toc425418723"></a><a class="pcalibre pcalibre1" id="_Toc425418575">The Letters of St. Ignatius of Antioch</a></h2>
+<h2 class="section-heading" id="calibre_pb_137"><a class="pcalibre pcalibre1" id="_Toc425418866"></a><a class="pcalibre pcalibre1" id="_Toc425418723"></a><a class="pcalibre pcalibre1" id="_Toc425418575">The Letters of St. Ignatius of Antioch</a></h2>
 
 <p class="msonormal1">Ignatius of Antioch was a man who was close in spirit and
 times to the Apostles. Whenever Ignatius uses the term “bishop,” he always

--- a/text/part0000_split_077.html
+++ b/text/part0000_split_077.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection33">
-<h2 class="calibre24" id="calibre_pb_138"><a class="pcalibre pcalibre1" id="_Toc425418867"></a><a class="pcalibre pcalibre1" id="_Toc425418724"></a><a class="pcalibre pcalibre1" id="_Toc425418576">Scriptural Evidence</a></h2>
+<h2 class="section-heading" id="calibre_pb_138"><a class="pcalibre pcalibre1" id="_Toc425418867"></a><a class="pcalibre pcalibre1" id="_Toc425418724"></a><a class="pcalibre pcalibre1" id="_Toc425418576">Scriptural Evidence</a></h2>
 
 <p class="msonormal1">When exploring the Scriptural evidence for the truth of the
 historical orthodox catholic position, one cannot help but immediately focus on

--- a/text/part0000_split_078.html
+++ b/text/part0000_split_078.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection33">
-<h2 class="calibre24" id="calibre_pb_139"><a class="pcalibre pcalibre1" id="_Toc425418868"></a><a class="pcalibre pcalibre1" id="_Toc425418725"></a><a class="pcalibre pcalibre1" id="_Toc425418577">St. Clement to the Corinthians</a></h2>
+<h2 class="section-heading" id="calibre_pb_139"><a class="pcalibre pcalibre1" id="_Toc425418868"></a><a class="pcalibre pcalibre1" id="_Toc425418725"></a><a class="pcalibre pcalibre1" id="_Toc425418577">St. Clement to the Corinthians</a></h2>
 
 <p class="msonormal1">St. Clement of Rome’s Epistle to the Corinthians, written
 before the end of the first century, should also be mentioned. Clement

--- a/text/part0000_split_079.html
+++ b/text/part0000_split_079.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection33">
-<h2 class="calibre24" id="calibre_pb_140"><a class="pcalibre pcalibre1" id="_Toc425418869"></a><a class="pcalibre pcalibre1" id="_Toc425418726"></a><a class="pcalibre pcalibre1" id="_Toc425418578">CONCLUSION</a></h2>
+<h2 class="section-heading" id="calibre_pb_140"><a class="pcalibre pcalibre1" id="_Toc425418869"></a><a class="pcalibre pcalibre1" id="_Toc425418726"></a><a class="pcalibre pcalibre1" id="_Toc425418578">CONCLUSION</a></h2>
 
 <p class="msonormal1">Because the Church is made manifest in the mystery of the
 Eucharist, the one ordained and consecrated to preside over its celebration

--- a/text/part0000_split_080.html
+++ b/text/part0000_split_080.html
@@ -11,7 +11,7 @@
 <h1 class="calibre9" id="calibre_pb_144"><a class="pcalibre pcalibre1" id="_Toc425418870"></a><a class="pcalibre pcalibre1" id="_Toc425418727"></a><a class="pcalibre pcalibre1" id="_Toc425418579"></a><a class="pcalibre pcalibre1" id="_Toc290636429"><span class="calibre25">APPENDIX B: <br class="calibre6"/>
 MATTH</span>EW 16:18—CHURCH AND APOSTLES</a></h1>
 
-<h2 class="calibre109"><a class="pcalibre pcalibre1" id="_Toc425418871"></a><a class="pcalibre pcalibre1" id="_Toc425418728"></a><a class="pcalibre pcalibre1" id="_Toc425418580"></a><a class="pcalibre pcalibre1" id="_Toc174267638">What is “the Church?”</a></h2>
+<h2 class="section-heading"><a class="pcalibre pcalibre1" id="_Toc425418871"></a><a class="pcalibre pcalibre1" id="_Toc425418728"></a><a class="pcalibre pcalibre1" id="_Toc425418580"></a><a class="pcalibre pcalibre1" id="_Toc174267638">What is “the Church?”</a></h2>
 
 <h3 class="calibre80"><a class="pcalibre pcalibre1" id="_Toc425418729"></a><a class="pcalibre pcalibre1" id="_Toc425418581"></a><a class="pcalibre pcalibre1" id="_Toc174267640">Defining the word</a></h3>
 

--- a/text/part0000_split_081.html
+++ b/text/part0000_split_081.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection34">
-<h2 class="calibre24" id="calibre_pb_145"><a class="pcalibre pcalibre1" id="_Toc425418872"></a><a class="pcalibre pcalibre1" id="_Toc425418732"></a><a class="pcalibre pcalibre1" id="_Toc425418584"></a><a class="pcalibre pcalibre1" id="_Toc174267643">UNITY IN THE (LOCAL</a><a title="" href="part0000_split_127.html#_edn2740" class="pcalibre pcalibre1" id="_ednref2740"><span class="msoendnotereference"><span class="calibre122"><span class="msoendnotereference"><b class="calibre7"><span class="calibre34"><span class="calibre123">[2740]</span></span></b></span></span></span></a>)
+<h2 class="section-heading" id="calibre_pb_145"><a class="pcalibre pcalibre1" id="_Toc425418872"></a><a class="pcalibre pcalibre1" id="_Toc425418732"></a><a class="pcalibre pcalibre1" id="_Toc425418584"></a><a class="pcalibre pcalibre1" id="_Toc174267643">UNITY IN THE (LOCAL</a><a title="" href="part0000_split_127.html#_edn2740" class="pcalibre pcalibre1" id="_ednref2740"><span class="msoendnotereference"><span class="calibre122"><span class="msoendnotereference"><b class="calibre7"><span class="calibre34"><span class="calibre123">[2740]</span></span></b></span></span></span></a>)
 CATHOLIC CHURCH</h2>
 
 <h3 class="calibre80"><a class="pcalibre pcalibre1" id="_Toc425418733"></a><a class="pcalibre pcalibre1" id="_Toc425418585"></a><a class="pcalibre pcalibre1" id="_Toc174267644">Who presides over the Eucharist?</a></h3>

--- a/text/part0000_split_082.html
+++ b/text/part0000_split_082.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection34">
-<h2 class="calibre24" id="calibre_pb_146"><a class="pcalibre pcalibre1" id="_Toc425418873"></a><a class="pcalibre pcalibre1" id="_Toc425418736"></a><a class="pcalibre pcalibre1" id="_Toc425418588"></a><a class="pcalibre pcalibre1" id="_Toc174267647">THE STRUCTURE OF THE CATHOLIC
+<h2 class="section-heading" id="calibre_pb_146"><a class="pcalibre pcalibre1" id="_Toc425418873"></a><a class="pcalibre pcalibre1" id="_Toc425418736"></a><a class="pcalibre pcalibre1" id="_Toc425418588"></a><a class="pcalibre pcalibre1" id="_Toc174267647">THE STRUCTURE OF THE CATHOLIC
 CHURCH</a></h2>
 
 <h3 class="calibre80"><a class="pcalibre pcalibre1" id="_Toc425418737"></a><a class="pcalibre pcalibre1" id="_Toc425418589"></a><a class="pcalibre pcalibre1" id="_Toc174267648">“One bishop in the catholic</a> Church”</h3>

--- a/text/part0000_split_083.html
+++ b/text/part0000_split_083.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection34">
-<h2 class="calibre24" id="calibre_pb_147"><a class="pcalibre pcalibre1" id="_Toc425418874"></a><a class="pcalibre pcalibre1" id="_Toc425418746"></a><a class="pcalibre pcalibre1" id="_Toc425418598"></a><a class="pcalibre pcalibre1" id="_Toc174267660">UNITY IN THE ‘UNIVERSAL
+<h2 class="section-heading" id="calibre_pb_147"><a class="pcalibre pcalibre1" id="_Toc425418874"></a><a class="pcalibre pcalibre1" id="_Toc425418746"></a><a class="pcalibre pcalibre1" id="_Toc425418598"></a><a class="pcalibre pcalibre1" id="_Toc174267660">UNITY IN THE ‘UNIVERSAL
 CHURCH’</a></h2>
 
 <h3 class="calibre80"><a class="pcalibre pcalibre1" id="_Toc425418747"></a><a class="pcalibre pcalibre1" id="_Toc425418599"></a><a class="pcalibre pcalibre1" id="_Toc174267661">Unity and forms of primacy</a></h3>

--- a/text/part0000_split_084.html
+++ b/text/part0000_split_084.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection34">
-<h2 class="calibre24" id="calibre_pb_148"><a class="pcalibre pcalibre1" id="_Toc425418875"></a><a class="pcalibre pcalibre1" id="_Toc425418751"></a><a class="pcalibre pcalibre1" id="_Toc425418603">THE ORTHODOX CHURCH TODAY</a></h2>
+<h2 class="section-heading" id="calibre_pb_148"><a class="pcalibre pcalibre1" id="_Toc425418875"></a><a class="pcalibre pcalibre1" id="_Toc425418751"></a><a class="pcalibre pcalibre1" id="_Toc425418603">THE ORTHODOX CHURCH TODAY</a></h2>
 
 <p class="msonormal1">It is then clear that the common idiom ‘(Eastern) Orthodox
 Church’ is a functional-practical expression which does not mean that Orthodoxy

--- a/text/part0000_split_085.html
+++ b/text/part0000_split_085.html
@@ -11,7 +11,7 @@
 <h1 class="calibre9" id="calibre_pb_152"><a class="pcalibre pcalibre1" id="_Toc425418876"></a><a class="pcalibre pcalibre1" id="_Toc425418752"></a><a class="pcalibre pcalibre1" id="_Toc425418604"></a><a class="pcalibre pcalibre1" id="_Toc290636430">APPENDIX C: <br class="calibre6"/>
 JOHN 1:1 and 18—JESUS AS “GOD</a>”</h1>
 
-<h2 class="calibre109"><a class="pcalibre pcalibre1" id="_Toc425418877"></a><a class="pcalibre pcalibre1" id="_Toc425418753"></a><a class="pcalibre pcalibre1" id="_Toc425418605">JOHN 1:1—THE WORD WAS {WHAT} GOD {WAS}</a></h2>
+<h2 class="section-heading"><a class="pcalibre pcalibre1" id="_Toc425418877"></a><a class="pcalibre pcalibre1" id="_Toc425418753"></a><a class="pcalibre pcalibre1" id="_Toc425418605">JOHN 1:1—THE WORD WAS {WHAT} GOD {WAS}</a></h2>
 
 <p class="msonormal1">Although the majority of modern translations render John
 1:1c as “and the Word was God,” this translation is somewhat problematic and

--- a/text/part0000_split_086.html
+++ b/text/part0000_split_086.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection35">
-<h2 class="calibre24" id="calibre_pb_153"><a class="pcalibre pcalibre1" id="_Toc425418878"></a><a class="pcalibre pcalibre1" id="_Toc425418754"></a><a class="pcalibre pcalibre1" id="_Toc425418606">JOHN 1:18—THE “UNIQUELY-BEGOTTEN” SON</a></h2>
+<h2 class="section-heading" id="calibre_pb_153"><a class="pcalibre pcalibre1" id="_Toc425418878"></a><a class="pcalibre pcalibre1" id="_Toc425418754"></a><a class="pcalibre pcalibre1" id="_Toc425418606">JOHN 1:18—THE “UNIQUELY-BEGOTTEN” SON</a></h2>
 
 <p class="msonormal1">John 1:18 presents a double difficulty. The first aspect is
 that the original Greek is debated. Several ancient manuscripts read <span>monogenh.j qeo.j</span> (“only-begotten or

--- a/text/part0000_split_087.html
+++ b/text/part0000_split_087.html
@@ -11,7 +11,7 @@
 <h1 class="calibre9" id="calibre_pb_157"><a class="pcalibre pcalibre1" id="_Toc425418879"></a><a class="pcalibre pcalibre1" id="_Toc425418755"></a><a class="pcalibre pcalibre1" id="_Toc425418607"></a><a class="pcalibre pcalibre1" id="_Toc290636431">APPENDIX D: <br class="calibre6"/>
 JOHN 15:26—THE FILIOQUE CONTROVERSY</a><a title="" href="part0000_split_127.html#_edn2823" class="pcalibre pcalibre1" id="_ednref2823"><span class="msoendnotereference"><span class="msoendnotereference"><b class="calibre7"><span class="calibre60">[2823]</span></b></span></span></a></h1>
 
-<h2 class="calibre109"><a class="pcalibre pcalibre1" id="_Toc425418880"></a><a class="pcalibre pcalibre1" id="_Toc425418756"></a><a class="pcalibre pcalibre1" id="_Toc425418608"><span class="calibre25">INTRODUCTION: </span></a><a class="pcalibre pcalibre1" id="_Toc174267787"><span class="calibre25">ECONOMY AND ONTOLOGY</span></a></h2>
+<h2 class="section-heading"><a class="pcalibre pcalibre1" id="_Toc425418880"></a><a class="pcalibre pcalibre1" id="_Toc425418756"></a><a class="pcalibre pcalibre1" id="_Toc425418608"><span class="calibre25">INTRODUCTION: </span></a><a class="pcalibre pcalibre1" id="_Toc174267787"><span class="calibre25">ECONOMY AND ONTOLOGY</span></a></h2>
 
 <p class="msonormal1">John 15:26 is the key text for the theological issue of the <i class="calibre4">filioque</i>
 which was and remains a major cause of debate and disagreement between

--- a/text/part0000_split_088.html
+++ b/text/part0000_split_088.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection36">
-<h2 class="calibre24" id="calibre_pb_158"><a class="pcalibre pcalibre1" id="_Toc425418881"></a><a class="pcalibre pcalibre1" id="_Toc425418757"></a><a class="pcalibre pcalibre1" id="_Toc425418609"></a><a class="pcalibre pcalibre1" id="_Toc174267788"><span class="calibre25">THE LATIN CREED</span></a></h2>
+<h2 class="section-heading" id="calibre_pb_158"><a class="pcalibre pcalibre1" id="_Toc425418881"></a><a class="pcalibre pcalibre1" id="_Toc425418757"></a><a class="pcalibre pcalibre1" id="_Toc425418609"></a><a class="pcalibre pcalibre1" id="_Toc174267788"><span class="calibre25">THE LATIN CREED</span></a></h2>
 
 <p class="msonormal1">The <i class="calibre4">filioque</i> is a modification of the Creed of Nicea-Constantinople (381) which was first introduced in Spain and which was
 eventually adopted by the Roman Catholic Church and many Protestant

--- a/text/part0000_split_089.html
+++ b/text/part0000_split_089.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection36">
-<h2 class="calibre24" id="calibre_pb_159"><a class="pcalibre pcalibre1" id="_Toc425418882"></a><a class="pcalibre pcalibre1" id="_Toc425418758"></a><a class="pcalibre pcalibre1" id="_Toc425418610"></a><a class="pcalibre pcalibre1" id="_Toc174267791"><span class="calibre25">“ONE GOD,” EAST AND WEST</span></a></h2>
+<h2 class="section-heading" id="calibre_pb_159"><a class="pcalibre pcalibre1" id="_Toc425418882"></a><a class="pcalibre pcalibre1" id="_Toc425418758"></a><a class="pcalibre pcalibre1" id="_Toc425418610"></a><a class="pcalibre pcalibre1" id="_Toc174267791"><span class="calibre25">“ONE GOD,” EAST AND WEST</span></a></h2>
 
 <p class="msonormal1">Because Paul Owen writes from a Western perspective, his
 presentation quickly reveals the root of the difference between the Greek and

--- a/text/part0000_split_090.html
+++ b/text/part0000_split_090.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection36">
-<h2 class="calibre24" id="calibre_pb_160"><a class="pcalibre pcalibre1" id="_Toc425418883"></a><a class="pcalibre pcalibre1" id="_Toc425418759"></a><a class="pcalibre pcalibre1" id="_Toc425418611"></a><a class="pcalibre pcalibre1" id="_Toc174267792"><span class="calibre25">THE FONT OF DEITY</span></a></h2>
+<h2 class="section-heading" id="calibre_pb_160"><a class="pcalibre pcalibre1" id="_Toc425418883"></a><a class="pcalibre pcalibre1" id="_Toc425418759"></a><a class="pcalibre pcalibre1" id="_Toc425418611"></a><a class="pcalibre pcalibre1" id="_Toc174267792"><span class="calibre25">THE FONT OF DEITY</span></a></h2>
 
 <p class="msonormal1">The article under consideration continues with a clear and
 helpful discussion of the essential difference of approach between East and

--- a/text/part0000_split_091.html
+++ b/text/part0000_split_091.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection36">
-<h2 class="calibre24" id="calibre_pb_161"><a class="pcalibre pcalibre1" id="_Toc425418884"></a><a class="pcalibre pcalibre1" id="_Toc425418760"></a><a class="pcalibre pcalibre1" id="_Toc425418612"></a><a class="pcalibre pcalibre1" id="_Toc174267793"><span lang="EN" class="calibre25">THE LATIN FILIOQUE: INTENT AND CONCERNS</span></a></h2>
+<h2 class="section-heading" id="calibre_pb_161"><a class="pcalibre pcalibre1" id="_Toc425418884"></a><a class="pcalibre pcalibre1" id="_Toc425418760"></a><a class="pcalibre pcalibre1" id="_Toc425418612"></a><a class="pcalibre pcalibre1" id="_Toc174267793"><span lang="EN" class="calibre25">THE LATIN FILIOQUE: INTENT AND CONCERNS</span></a></h2>
 
 <p class="msonormal1"><span lang="EN">Let us consider point (2), “</span>that the
 intention of the filioque is different than that of the creed of 381.” Orthodox

--- a/text/part0000_split_092.html
+++ b/text/part0000_split_092.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection36">
-<h2 class="calibre24" id="calibre_pb_162"><a class="pcalibre pcalibre1" id="_Toc425418885"></a><a class="pcalibre pcalibre1" id="_Toc425418761"></a><a class="pcalibre pcalibre1" id="_Toc425418613"></a><a class="pcalibre pcalibre1" id="_Toc174267794"><span class="calibre25">FROM THE FATHER THROUGH THE SON?</span></a></h2>
+<h2 class="section-heading" id="calibre_pb_162"><a class="pcalibre pcalibre1" id="_Toc425418885"></a><a class="pcalibre pcalibre1" id="_Toc425418761"></a><a class="pcalibre pcalibre1" id="_Toc425418613"></a><a class="pcalibre pcalibre1" id="_Toc174267794"><span class="calibre25">FROM THE FATHER THROUGH THE SON?</span></a></h2>
 
 <p class="msonormal1">We now arrive at an expression that is acceptable on both
 sides because of its patristic use: that the Spirit proceeds (<i class="calibre4">procedit-proinai</i>)

--- a/text/part0000_split_093.html
+++ b/text/part0000_split_093.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection36">
-<h2 class="calibre24" id="calibre_pb_163"><a class="pcalibre pcalibre1" id="_Toc425418886"></a><a class="pcalibre pcalibre1" id="_Toc425418762"></a><a class="pcalibre pcalibre1" id="_Toc425418614"></a><a class="pcalibre pcalibre1" id="_Toc174267795"><span class="calibre25">REVISIONIST THEOLOGY?</span></a></h2>
+<h2 class="section-heading" id="calibre_pb_163"><a class="pcalibre pcalibre1" id="_Toc425418886"></a><a class="pcalibre pcalibre1" id="_Toc425418762"></a><a class="pcalibre pcalibre1" id="_Toc425418614"></a><a class="pcalibre pcalibre1" id="_Toc174267795"><span class="calibre25">REVISIONIST THEOLOGY?</span></a></h2>
 
 <p class="msonormal1">There is another valid reason for which Orthodox are loath
 to concede to an acceptable (or even positive) interpretation of the <i class="calibre4">filioque</i>,

--- a/text/part0000_split_094.html
+++ b/text/part0000_split_094.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection36">
-<h2 class="calibre24" id="calibre_pb_164"><a class="pcalibre pcalibre1" id="_Toc425418887"></a><a class="pcalibre pcalibre1" id="_Toc425418763"></a><a class="pcalibre pcalibre1" id="_Toc425418615">THE TRINITY</a></h2>
+<h2 class="section-heading" id="calibre_pb_164"><a class="pcalibre pcalibre1" id="_Toc425418887"></a><a class="pcalibre pcalibre1" id="_Toc425418763"></a><a class="pcalibre pcalibre1" id="_Toc425418615">THE TRINITY</a></h2>
 
 <p class="msonormal1">Perhaps one reason for the mystery and abstract complexity
 of this issue is that few people understand what (or better who) the Holy

--- a/text/part0000_split_095.html
+++ b/text/part0000_split_095.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection36">
-<h2 class="calibre24" id="calibre_pb_165"><a class="pcalibre pcalibre1" id="_Toc425418888"></a><a class="pcalibre pcalibre1" id="_Toc425418764"></a><a class="pcalibre pcalibre1" id="_Toc425418616"></a><a class="pcalibre pcalibre1" id="_Toc174267797"><span class="calibre25">THE FEAR OF ARIANISM</span></a></h2>
+<h2 class="section-heading" id="calibre_pb_165"><a class="pcalibre pcalibre1" id="_Toc425418888"></a><a class="pcalibre pcalibre1" id="_Toc425418764"></a><a class="pcalibre pcalibre1" id="_Toc425418616"></a><a class="pcalibre pcalibre1" id="_Toc174267797"><span class="calibre25">THE FEAR OF ARIANISM</span></a></h2>
 
 <p class="msonormal1">It may be useful to mention that the ‘shadow of Arianism’—and the fear thereof—may be more of a factor than is often realized. For various
 reasons, what we call the Western tradition has tended to theologize on the

--- a/text/part0000_split_096.html
+++ b/text/part0000_split_096.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection36">
-<h2 class="calibre24" id="calibre_pb_166"><a class="pcalibre pcalibre1" id="_Toc425418889"></a><a class="pcalibre pcalibre1" id="_Toc425418765"></a><a class="pcalibre pcalibre1" id="_Toc425418617"></a><a class="pcalibre pcalibre1" id="_Toc174267798"><span class="calibre25">IN SUMMARY</span></a></h2>
+<h2 class="section-heading" id="calibre_pb_166"><a class="pcalibre pcalibre1" id="_Toc425418889"></a><a class="pcalibre pcalibre1" id="_Toc425418765"></a><a class="pcalibre pcalibre1" id="_Toc425418617"></a><a class="pcalibre pcalibre1" id="_Toc174267798"><span class="calibre25">IN SUMMARY</span></a></h2>
 
 <p class="msonormal1">Many leading Orthodox theologians agree that a statement of
 faith could be produced with an orthodox <i class="calibre4">filioque</i>, as was done by St.

--- a/text/part0000_split_098.html
+++ b/text/part0000_split_098.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection37">
-<h2 class="calibre24" id="calibre_pb_173"><a class="pcalibre pcalibre1" id="_Toc425418891"></a><a class="pcalibre pcalibre1" id="_Toc425418767"></a><a class="pcalibre pcalibre1" id="_Toc425418619">THREE VIEWS</a></h2>
+<h2 class="section-heading" id="calibre_pb_173"><a class="pcalibre pcalibre1" id="_Toc425418891"></a><a class="pcalibre pcalibre1" id="_Toc425418767"></a><a class="pcalibre pcalibre1" id="_Toc425418619">THREE VIEWS</a></h2>
 
 <p class="msonormal1">Three theories have been presented to account for the
 complex philological,<a title="" href="part0000_split_127.html#_edn2852" class="pcalibre pcalibre1" id="_ednref2852"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2852]</span></span></span></a>

--- a/text/part0000_split_099.html
+++ b/text/part0000_split_099.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection37">
-<h2 class="calibre24" id="calibre_pb_174"><a class="pcalibre pcalibre1" id="_Toc425418892"></a><a class="pcalibre pcalibre1" id="_Toc425418768"></a><a class="pcalibre pcalibre1" id="_Toc425418620">DOGMAS AND CONVICTIONS</a></h2>
+<h2 class="section-heading" id="calibre_pb_174"><a class="pcalibre pcalibre1" id="_Toc425418892"></a><a class="pcalibre pcalibre1" id="_Toc425418768"></a><a class="pcalibre pcalibre1" id="_Toc425418620">DOGMAS AND CONVICTIONS</a></h2>
 
 <p class="msonormal1">From an Eastern Orthodox perspective, it is important to
 understand that the Orthodox Faith does not include Marian dogmas as such: even

--- a/text/part0000_split_100.html
+++ b/text/part0000_split_100.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection37">
-<h2 class="calibre24" id="calibre_pb_175"><a class="pcalibre pcalibre1" id="_Toc425418893"></a><a class="pcalibre pcalibre1" id="_Toc425418769"></a><a class="pcalibre pcalibre1" id="_Toc425418621">THE NEW TESTAMENT TEXTS</a></h2>
+<h2 class="section-heading" id="calibre_pb_175"><a class="pcalibre pcalibre1" id="_Toc425418893"></a><a class="pcalibre pcalibre1" id="_Toc425418769"></a><a class="pcalibre pcalibre1" id="_Toc425418621">THE NEW TESTAMENT TEXTS</a></h2>
 
 <p class="msonormal1">This exegesis by a native Greek speaker and Biblical exegete
 leads us back to the question of the Scriptural terminology:</p>

--- a/text/part0000_split_101.html
+++ b/text/part0000_split_101.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection37">
-<h2 class="calibre24" id="calibre_pb_176"><a class="pcalibre pcalibre1" id="_Toc425418894"></a><a class="pcalibre pcalibre1" id="_Toc425418770"></a><a class="pcalibre pcalibre1" id="_Toc425418622">POSITIVE EVIDENCE AND INDICATIONS</a></h2>
+<h2 class="section-heading" id="calibre_pb_176"><a class="pcalibre pcalibre1" id="_Toc425418894"></a><a class="pcalibre pcalibre1" id="_Toc425418770"></a><a class="pcalibre pcalibre1" id="_Toc425418622">POSITIVE EVIDENCE AND INDICATIONS</a></h2>
 
 <p class="msonormal1">Mark 6:3, which mentions the <i class="calibre4">adelphoi</i> of Jesus, may
 also indicate that only Jesus was <i class="calibre4">the</i> son of Mary:</p>

--- a/text/part0000_split_102.html
+++ b/text/part0000_split_102.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection37">
-<h2 class="calibre24" id="calibre_pb_177"><a class="pcalibre pcalibre1" id="_Toc425418895"></a><a class="pcalibre pcalibre1" id="_Toc425418771"></a><a class="pcalibre pcalibre1" id="_Toc425418623">THEOLOGY AND TYPOLOGY</a></h2>
+<h2 class="section-heading" id="calibre_pb_177"><a class="pcalibre pcalibre1" id="_Toc425418895"></a><a class="pcalibre pcalibre1" id="_Toc425418771"></a><a class="pcalibre pcalibre1" id="_Toc425418623">THEOLOGY AND TYPOLOGY</a></h2>
 
 <p class="msonormal1">In addition to the historic-textual data discussed above,
 the fact that the inspired Scriptures present the Theotokos as the antitype of

--- a/text/part0000_split_103.html
+++ b/text/part0000_split_103.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection37">
-<h2 class="calibre24" id="calibre_pb_178"><a class="pcalibre pcalibre1" id="_Toc425418896"></a><a class="pcalibre pcalibre1" id="_Toc425418772"></a><a class="pcalibre pcalibre1" id="_Toc425418624">EARLY CHRISTIAN WITNESSES</a></h2>
+<h2 class="section-heading" id="calibre_pb_178"><a class="pcalibre pcalibre1" id="_Toc425418896"></a><a class="pcalibre pcalibre1" id="_Toc425418772"></a><a class="pcalibre pcalibre1" id="_Toc425418624">EARLY CHRISTIAN WITNESSES</a></h2>
 
 <p class="msonormal1">Writing in the middle of the second century, Origen was
 aware of at least two pre-existing texts which affirmed the Epiphanian view:

--- a/text/part0000_split_104.html
+++ b/text/part0000_split_104.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection37">
-<h2 class="calibre24" id="calibre_pb_179"><a class="pcalibre pcalibre1" id="_Toc425418897"></a><a class="pcalibre pcalibre1" id="_Toc425418773"></a><a class="pcalibre pcalibre1" id="_Toc425418625">INVESTIGATING JAMES AND ‘THE OTHER MARY:’ A WORD ABOUT THE
+<h2 class="section-heading" id="calibre_pb_179"><a class="pcalibre pcalibre1" id="_Toc425418897"></a><a class="pcalibre pcalibre1" id="_Toc425418773"></a><a class="pcalibre pcalibre1" id="_Toc425418625">INVESTIGATING JAMES AND ‘THE OTHER MARY:’ A WORD ABOUT THE
 JEROMIAN VIEW</a></h2>
 
 <p class="msonormal1">The theory proposed by St. Jerome is that the <i class="calibre4">adelphoi</i>

--- a/text/part0000_split_105.html
+++ b/text/part0000_split_105.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection37">
-<h2 class="calibre24" id="calibre_pb_180"><a class="pcalibre pcalibre1" id="_Toc425418898"></a><a class="pcalibre pcalibre1" id="_Toc425418774"></a><a class="pcalibre pcalibre1" id="_Toc425418626">SUMMARY</a></h2>
+<h2 class="section-heading" id="calibre_pb_180"><a class="pcalibre pcalibre1" id="_Toc425418898"></a><a class="pcalibre pcalibre1" id="_Toc425418774"></a><a class="pcalibre pcalibre1" id="_Toc425418626">SUMMARY</a></h2>
 
 <p class="msonormal1">The same Fathers who discerned the canon of the New
 Testament, read Greek natively, and left us a model of reverence for the

--- a/text/part0000_split_107.html
+++ b/text/part0000_split_107.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection37">
-<h2 class="calibre24" id="calibre_pb_183"><a class="pcalibre pcalibre1" id="_Toc425418900"></a><a class="pcalibre pcalibre1" id="_Toc425418776"></a><a class="pcalibre pcalibre1" id="_Toc425418628">INTERNAL EVIDENCE</a></h2>
+<h2 class="section-heading" id="calibre_pb_183"><a class="pcalibre pcalibre1" id="_Toc425418900"></a><a class="pcalibre pcalibre1" id="_Toc425418776"></a><a class="pcalibre pcalibre1" id="_Toc425418628">INTERNAL EVIDENCE</a></h2>
 
 <p class="msonormal1">Besides the manuscript evidence, some scholars appeal to
 internal evidence to support their contention that Mark 16:9-20 is a scribal

--- a/text/part0000_split_108.html
+++ b/text/part0000_split_108.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection37">
-<h2 class="calibre24" id="calibre_pb_184"><a class="pcalibre pcalibre1" id="_Toc425418901"></a><a class="pcalibre pcalibre1" id="_Toc425418777"></a><a class="pcalibre pcalibre1" id="_Toc425418629">A POSSIBLE AUTHOR FOR MARK’S ENDING</a></h2>
+<h2 class="section-heading" id="calibre_pb_184"><a class="pcalibre pcalibre1" id="_Toc425418901"></a><a class="pcalibre pcalibre1" id="_Toc425418777"></a><a class="pcalibre pcalibre1" id="_Toc425418629">A POSSIBLE AUTHOR FOR MARK’S ENDING</a></h2>
 
 <p class="msonormal1">There is another possibility to explain the abrupt ending in
 16:8 and the different feel of the Longer Ending: that someone other than Mark

--- a/text/part0000_split_109.html
+++ b/text/part0000_split_109.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection37">
-<h2 class="calibre24" id="calibre_pb_185"><a class="pcalibre pcalibre1" id="_Toc425418902"></a><a class="pcalibre pcalibre1" id="_Toc425418778"></a><a class="pcalibre pcalibre1" id="_Toc425418630">EXTERNAL / MANUSCRIPT EVIDENCE</a></h2>
+<h2 class="section-heading" id="calibre_pb_185"><a class="pcalibre pcalibre1" id="_Toc425418902"></a><a class="pcalibre pcalibre1" id="_Toc425418778"></a><a class="pcalibre pcalibre1" id="_Toc425418630">EXTERNAL / MANUSCRIPT EVIDENCE</a></h2>
 
 <p class="msonormal1">We now turn to the external evidence. Over 1,500 Greek
 copies of the Gospel of Mark exist. Only two of those MSS end the Gospel of

--- a/text/part0000_split_110.html
+++ b/text/part0000_split_110.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection37">
-<h2 class="calibre24" id="calibre_pb_186"><a class="pcalibre pcalibre1" id="_Toc425418903"></a><a class="pcalibre pcalibre1" id="_Toc425418779"></a><a class="pcalibre pcalibre1" id="_Toc425418631">EARLY CHURCH WRITERS</a></h2>
+<h2 class="section-heading" id="calibre_pb_186"><a class="pcalibre pcalibre1" id="_Toc425418903"></a><a class="pcalibre pcalibre1" id="_Toc425418779"></a><a class="pcalibre pcalibre1" id="_Toc425418631">EARLY CHURCH WRITERS</a></h2>
 
 <p class="msonormal1">Furthermore, evidence that is older than Vaticanus and
 Sinaiticus strongly supports Mark 16:9-20 as part of the Gospel of Mark. Our

--- a/text/part0000_split_111.html
+++ b/text/part0000_split_111.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection37">
-<h2 class="calibre24" id="calibre_pb_187"><a class="pcalibre pcalibre1" id="_Toc425418904"></a><a class="pcalibre pcalibre1" id="_Toc425418780"></a><a class="pcalibre pcalibre1" id="_Toc425418632">THE ABRUPT AND SHORTER ENDING</a></h2>
+<h2 class="section-heading" id="calibre_pb_187"><a class="pcalibre pcalibre1" id="_Toc425418904"></a><a class="pcalibre pcalibre1" id="_Toc425418780"></a><a class="pcalibre pcalibre1" id="_Toc425418632">THE ABRUPT AND SHORTER ENDING</a></h2>
 
 <p class="msonormal1">We could also consider additional evidence for the ending at
 16:8. Besides Codex Vaticanus and Codex Sinaiticus, two non-Greek copies — the

--- a/text/part0000_split_112.html
+++ b/text/part0000_split_112.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection37">
-<h2 class="calibre24" id="calibre_pb_188"><a class="pcalibre pcalibre1" id="_Toc425418905"></a><a class="pcalibre pcalibre1" id="_Toc425418781"></a><a class="pcalibre pcalibre1" id="_Toc425418633">THE CASE OF CLEMENT AND ORIGEN</a></h2>
+<h2 class="section-heading" id="calibre_pb_188"><a class="pcalibre pcalibre1" id="_Toc425418905"></a><a class="pcalibre pcalibre1" id="_Toc425418781"></a><a class="pcalibre pcalibre1" id="_Toc425418633">THE CASE OF CLEMENT AND ORIGEN</a></h2>
 
 <p class="msonormal1">We now turn to evidence against the inclusion of Mark
 16:9-20, notably the testimony of Clement of Alexandria (who died in the early

--- a/text/part0000_split_113.html
+++ b/text/part0000_split_113.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection37">
-<h2 class="calibre24" id="calibre_pb_189"><a class="pcalibre pcalibre1" id="_Toc425418906"></a><a class="pcalibre pcalibre1" id="_Toc425418782"></a><a class="pcalibre pcalibre1" id="_Toc425418634"><span class="calibre25">ETHIOPIC VERSIONS</span></a></h2>
+<h2 class="section-heading" id="calibre_pb_189"><a class="pcalibre pcalibre1" id="_Toc425418906"></a><a class="pcalibre pcalibre1" id="_Toc425418782"></a><a class="pcalibre pcalibre1" id="_Toc425418634"><span class="calibre25">ETHIOPIC VERSIONS</span></a></h2>
 
 <p class="msonormal1">Regarding the Ethiopic version, it should be noted that some
 commentators claim that Mark 16:9-20 is absent from some of these copies.

--- a/text/part0000_split_114.html
+++ b/text/part0000_split_114.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection37">
-<h2 class="calibre24" id="calibre_pb_190"><a class="pcalibre pcalibre1" id="_Toc425418907"></a><a class="pcalibre pcalibre1" id="_Toc425418783"></a><a class="pcalibre pcalibre1" id="_Toc425418635">POSSIBLE TRANSMISSION STREAM</a></h2>
+<h2 class="section-heading" id="calibre_pb_190"><a class="pcalibre pcalibre1" id="_Toc425418907"></a><a class="pcalibre pcalibre1" id="_Toc425418783"></a><a class="pcalibre pcalibre1" id="_Toc425418635">POSSIBLE TRANSMISSION STREAM</a></h2>
 
 <p class="msonormal1"><span>When we view all of this external
 evidence together, it is clear that the evidence for the inclusion of Mark

--- a/text/part0000_split_115.html
+++ b/text/part0000_split_115.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection37">
-<h2 class="calibre24" id="calibre_pb_191"><a class="pcalibre pcalibre1" id="_Toc425418908"></a><a class="pcalibre pcalibre1" id="_Toc425418784"></a><a class="pcalibre pcalibre1" id="_Toc425418636">ECCLESIATICAL USE</a></h2>
+<h2 class="section-heading" id="calibre_pb_191"><a class="pcalibre pcalibre1" id="_Toc425418908"></a><a class="pcalibre pcalibre1" id="_Toc425418784"></a><a class="pcalibre pcalibre1" id="_Toc425418636">ECCLESIATICAL USE</a></h2>
 
 <p class="msonormal1"><span>Besides all the data from
 patristic quotations and Greek MSS, there is also the evidence from the

--- a/text/part0000_split_117.html
+++ b/text/part0000_split_117.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection38">
-<h2 class="calibre24" id="calibre_pb_196"><a class="pcalibre pcalibre1" id="_Toc425418910"></a><a class="pcalibre pcalibre1" id="_Toc425418786"></a><a class="pcalibre pcalibre1" id="_Toc425418638">DID THE ORIGINAL LUKE INCLUDE THE SECOND CAINAN?</a></h2>
+<h2 class="section-heading" id="calibre_pb_196"><a class="pcalibre pcalibre1" id="_Toc425418910"></a><a class="pcalibre pcalibre1" id="_Toc425418786"></a><a class="pcalibre pcalibre1" id="_Toc425418638">DID THE ORIGINAL LUKE INCLUDE THE SECOND CAINAN?</a></h2>
 
 <p class="msonormal1"><b class="calibre7">The first hypothesis to be tested is that Luke did not
 include this second Cainan</b> but that a very early copyist accidentally

--- a/text/part0000_split_118.html
+++ b/text/part0000_split_118.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection38">
-<h2 class="calibre24" id="calibre_pb_197"><a class="pcalibre pcalibre1" id="_Toc425418911"></a><a class="pcalibre pcalibre1" id="_Toc425418787"></a><a class="pcalibre pcalibre1" id="_Toc425418639">THE RELATIONSHIP BETWEEN LUKE AND THE LXX</a></h2>
+<h2 class="section-heading" id="calibre_pb_197"><a class="pcalibre pcalibre1" id="_Toc425418911"></a><a class="pcalibre pcalibre1" id="_Toc425418787"></a><a class="pcalibre pcalibre1" id="_Toc425418639">THE RELATIONSHIP BETWEEN LUKE AND THE LXX</a></h2>
 
 <p class="msonormal1">In short, the question is, “did Luke follow the LXX or did
 the (Christian) LXX copy Luke?” If Luke actually included the second Cainan –

--- a/text/part0000_split_119.html
+++ b/text/part0000_split_119.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection38">
-<h2 class="calibre24" id="calibre_pb_198"><a class="pcalibre pcalibre1" id="_Toc425418912"></a><a class="pcalibre pcalibre1" id="_Toc425418788"></a><a class="pcalibre pcalibre1" id="_Toc425418640">TWO STREAMS OF TRADITION?</a></h2>
+<h2 class="section-heading" id="calibre_pb_198"><a class="pcalibre pcalibre1" id="_Toc425418912"></a><a class="pcalibre pcalibre1" id="_Toc425418788"></a><a class="pcalibre pcalibre1" id="_Toc425418640">TWO STREAMS OF TRADITION?</a></h2>
 
 <p class="msonormal1">In view of the above, another theory to be suggested is that
 the second Cainan was removed by Jews (both before Christ and after through the

--- a/text/part0000_split_120.html
+++ b/text/part0000_split_120.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection38">
-<h2 class="calibre24" id="calibre_pb_199"><a class="pcalibre pcalibre1" id="_Toc425418913"></a><a class="pcalibre pcalibre1" id="_Toc425418789"></a><a class="pcalibre pcalibre1" id="_Toc425418641">UNDERSTANDING THE PATTERNS</a></h2>
+<h2 class="section-heading" id="calibre_pb_199"><a class="pcalibre pcalibre1" id="_Toc425418913"></a><a class="pcalibre pcalibre1" id="_Toc425418789"></a><a class="pcalibre pcalibre1" id="_Toc425418641">UNDERSTANDING THE PATTERNS</a></h2>
 
 <p class="msonormal1">Why did the Masoretes apply a formula of 100 year reduction
 in six names, and not apply the same formula to Jared, Methuselah and Lamech?

--- a/text/part0000_split_121.html
+++ b/text/part0000_split_121.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection38">
-<h2 class="calibre24" id="calibre_pb_200"><a class="pcalibre pcalibre1" id="_Toc425418914"></a><a class="pcalibre pcalibre1" id="_Toc425418790"></a><a class="pcalibre pcalibre1" id="_Toc425418642"><span class="calibre25">ABRAHAM’S GENERATION</span></a></h2>
+<h2 class="section-heading" id="calibre_pb_200"><a class="pcalibre pcalibre1" id="_Toc425418914"></a><a class="pcalibre pcalibre1" id="_Toc425418790"></a><a class="pcalibre pcalibre1" id="_Toc425418642"><span class="calibre25">ABRAHAM’S GENERATION</span></a></h2>
 
 <p class="msonormal1">Throughout history Abraham was referred to as the 10<sup class="calibre31">th</sup>
 generation from the Flood, which would be erroneous if the Masoretic and

--- a/text/part0000_split_122.html
+++ b/text/part0000_split_122.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 <div class="wordsection38">
-<h2 class="calibre24" id="calibre_pb_201"><a class="pcalibre pcalibre1" id="_Toc425418915"></a><a class="pcalibre pcalibre1" id="_Toc425418791"></a><a class="pcalibre pcalibre1" id="_Toc425418643">SUMMARY</a></h2>
+<h2 class="section-heading" id="calibre_pb_201"><a class="pcalibre pcalibre1" id="_Toc425418915"></a><a class="pcalibre pcalibre1" id="_Toc425418791"></a><a class="pcalibre pcalibre1" id="_Toc425418643">SUMMARY</a></h2>
 
 <p class="msonormal1">The question of the second Cainan begins with Luke 3:36 but
 clearly has wider implications. Although it is extremely difficult to be


### PR DESCRIPTION
## Summary
- add a single `.section-heading` style in `stylesheet.css` for the shared heading presentation
- update the affected XHTML content files to reference the new class and drop the redundant `.calibre24`/`.calibre109` rules

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7e5d03b108329b300a9959372f384