### PR TITLE
Refactor Word section wrappers to semantic classes

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -2246,28 +2246,14 @@
     text-indent: 0;
     margin: 6pt 0 0.0001pt
     }
-.style35ptloweredby1ptlinespacingexactly2445pt {
+.section {
     display: block;
-    font-size: 1.2em;
-    line-height: 1.2;
-    position: relative;
-    text-autospace: none;
-    text-indent: 0;
-    top: 1pt;
-    margin: 0 0 0.0001pt
+    line-height: 1.2
     }
-.style37ptbefore0ptloweredby6ptlinespacingexactl {
-    display: block;
-    font-size: 1.2em;
-    line-height: 1.2;
-    page-break-after: avoid;
-    position: relative;
-    text-autospace: none;
-    text-indent: 0;
-    top: 6pt;
-    margin: 0 0 0.0001pt
+.section + .section {
+    break-before: page
     }
-.style38ptloweredby2ptlinespacingexactly2445pt {
+.chapter-number {
     display: block;
     font-size: 1.2em;
     line-height: 1.2;
@@ -2275,267 +2261,38 @@
     position: relative;
     text-autospace: none;
     text-indent: 0;
-    top: 2pt;
-    margin: 0 0 0.0001pt
+    margin: 0
     }
-.style345ptloweredby15ptlinespacingexactly2445pt {
-    display: block;
-    font-size: 1.2em;
-    line-height: 1.2;
-    page-break-after: avoid;
-    position: relative;
-    text-autospace: none;
-    text-indent: 0;
-    top: 1.5pt;
-    margin: 0 0 0.0001pt
+.chapter-number--nudge-1 {
+    top: 1pt
     }
-.style365ptloweredby1ptlinespacingexactly2445pt {
-    display: block;
-    font-size: 1.2em;
-    line-height: 1.2;
-    page-break-after: avoid;
-    position: relative;
-    text-autospace: none;
-    text-indent: 0;
-    top: 1pt;
-    margin: 0 0 0.0001pt
+.chapter-number--nudge-1-5 {
+    top: 1.5pt
     }
-.style375ptbefore0ptloweredby7ptlinespacingexac {
-    display: block;
-    font-size: 1.2em;
-    line-height: 1.2;
-    page-break-after: avoid;
-    position: relative;
-    text-autospace: none;
-    text-indent: 0;
-    top: 7pt;
-    margin: 0 0 0.0001pt
+.chapter-number--nudge-2 {
+    top: 2pt
     }
-.style375ptloweredby15ptlinespacingexactly2445pt {
-    display: block;
-    font-size: 1.2em;
-    line-height: 1.2;
-    position: relative;
-    text-autospace: none;
-    text-indent: 0;
-    top: 1.5pt;
-    margin: 0 0 0.0001pt
+.chapter-number--nudge-6 {
+    top: 6pt
     }
-.stylefootnotereferencelatinitalicblack {
+.chapter-number--nudge-7 {
+    top: 7pt
+    }
+.footnote-ref {
     text-decoration: none;
     vertical-align: super
     }
-.stylefranklingothicbook10ptleft {
+.definition-term {
     display: block;
     font-size: 0.6em;
     text-indent: 0.2in;
-    margin: 0 0 0.0001pt
+    margin: 0
     }
-.stylefranklingothicbook10ptleft1 {
+.definition-detail {
     display: block;
     font-size: 0.6em;
     text-indent: 0;
-    margin: 0 0 0.0001pt
-    }
-.wordsection {
-    display: block;
-    line-height: 1.2;
-    page: WordSection1
-    }
-.wordsection1 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection2
-    }
-.wordsection2 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection3
-    }
-.wordsection3 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection4
-    }
-.wordsection4 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection5
-    }
-.wordsection5 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection6
-    }
-.wordsection6 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection7
-    }
-.wordsection7 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection8
-    }
-.wordsection8 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection9
-    }
-.wordsection9 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection10
-    }
-.wordsection10 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection11
-    }
-.wordsection11 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection12
-    }
-.wordsection12 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection13
-    }
-.wordsection13 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection14
-    }
-.wordsection14 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection15
-    }
-.wordsection15 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection16
-    }
-.wordsection16 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection17
-    }
-.wordsection17 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection18
-    }
-.wordsection18 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection19
-    }
-.wordsection19 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection20
-    }
-.wordsection20 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection21
-    }
-.wordsection21 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection22
-    }
-.wordsection22 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection23
-    }
-.wordsection23 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection24
-    }
-.wordsection24 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection25
-    }
-.wordsection25 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection26
-    }
-.wordsection26 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection27
-    }
-.wordsection27 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection28
-    }
-.wordsection28 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection29
-    }
-.wordsection29 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection30
-    }
-.wordsection30 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection31
-    }
-.wordsection31 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection32
-    }
-.wordsection32 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection33
-    }
-.wordsection33 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection34
-    }
-.wordsection34 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection35
-    }
-.wordsection35 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection36
-    }
-.wordsection36 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection37
-    }
-.wordsection37 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection38
-    }
-.wordsection38 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection39
-    }
-.wordsection39 {
-    display: block;
-    line-height: 1.2;
-    page: WordSection40
+    margin: 0
     }
 .pcalibre:visited {
     color: purple;

--- a/text/part0000_split_000.html
+++ b/text/part0000_split_000.html
@@ -8,7 +8,7 @@
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 
-<div class="wordsection">
+<div class="section">
 
 <p class="msonormal"><span class="calibre1"> </span></p>
 

--- a/text/part0000_split_001.html
+++ b/text/part0000_split_001.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection">
+<div class="section">
 <span class="calibre5">
 <br clear="all" class="calibre6" id="calibre_pb_1"/>
 </span>

--- a/text/part0000_split_002.html
+++ b/text/part0000_split_002.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_5"><a class="pcalibre pcalibre1" id="_Toc425418794"></a><a class="pcalibre pcalibre1" id="_Toc425418646"></a><a class="pcalibre pcalibre1" id="_Toc425418498"></a><a class="pcalibre pcalibre1" id="_Toc290636392"></a><a class="pcalibre pcalibre1" id="toc"></a>TABLE OF
 CONTENTS</h1>
 
@@ -326,7 +326,7 @@ LUKE AND THE LXX</a></p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection1">
+<div class="section">
 
 <p class="msonormal1"> </p>
 

--- a/text/part0000_split_003.html
+++ b/text/part0000_split_003.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection1">
+<div class="section">
 <div class="calibre11">
 <p class="heading1b" id="calibre_pb_7"><a class="pcalibre pcalibre1" id="_Toc425418795"></a><a class="pcalibre pcalibre1" id="_Toc425418647"></a><a class="pcalibre pcalibre1" id="_Toc425418499"></a><a class="pcalibre pcalibre1" id="_Toc290636393">THE
 GREEK ALPHABET</a></p>

--- a/text/part0000_split_004.html
+++ b/text/part0000_split_004.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection1">
+<div class="section">
 <div class="calibre11">
 <p class="heading1b" id="calibre_pb_9"><a class="pcalibre pcalibre1" id="_Toc425418796"></a><a class="pcalibre pcalibre1" id="_Toc425418648"></a><a class="pcalibre pcalibre1" id="_Toc425418500"></a><a class="pcalibre pcalibre1" id="_Toc290636394">MANUSCRIPT
 CODES</a></p>

--- a/text/part0000_split_005.html
+++ b/text/part0000_split_005.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection1">
+<div class="section">
 <div class="calibre11">
 <p class="heading1b" id="calibre_pb_11"><a class="pcalibre pcalibre1" id="_Toc425418797"></a><a class="pcalibre pcalibre1" id="_Toc425418649"></a><a class="pcalibre pcalibre1" id="_Toc425418501"></a><a class="pcalibre pcalibre1" id="_Toc290636395">ABOUT
 THE EOB NEW TESTAMENT</a></p>

--- a/text/part0000_split_006.html
+++ b/text/part0000_split_006.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection1">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_12"><a class="pcalibre pcalibre1" id="_Toc425418798"></a><a class="pcalibre pcalibre1" id="_Toc425418650"></a><a class="pcalibre pcalibre1" id="_Toc425418502"><span class="calibre25">PURPOSE</span></a></h2>
 
 <p class="msonormal1">The EOB New Testament was prepared for personal study and
@@ -84,7 +84,7 @@ proper ecclesiastical use in an Orthodox context.</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection2">
+<div class="section">
 
 <p class="msonormal1"><a title="" href="part0000_split_124.html#_edn1" class="pcalibre pcalibre1" id="_ednref1"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1]</span></span></span></a></p>
 

--- a/text/part0000_split_007.html
+++ b/text/part0000_split_007.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection2">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_13"><a class="pcalibre pcalibre1" id="_Toc425418799"></a><a class="pcalibre pcalibre1" id="_Toc425418651"></a><a class="pcalibre pcalibre1" id="_Toc425418503">EOB FOOTNOTES</a></h2>
 
 <p class="msonormal1">Unlike the <b class="calibre7">Orthodox Study Bible (OSB)</b>, the EOB

--- a/text/part0000_split_008.html
+++ b/text/part0000_split_008.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection2">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_14"><a class="pcalibre pcalibre1" id="_Toc425418800"></a><a class="pcalibre pcalibre1" id="_Toc425418652"></a><a class="pcalibre pcalibre1" id="_Toc425418504">PRIMARY GREEK TEXT(S)</a></h2>
 
 <p class="msonormal1">The translation of the New Testament included in the EOB is

--- a/text/part0000_split_009.html
+++ b/text/part0000_split_009.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection2">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_15"><a class="pcalibre pcalibre1" id="_Toc425418801"></a><a class="pcalibre pcalibre1" id="_Toc425418653"></a><a class="pcalibre pcalibre1" id="_Toc425418505">UNDERSTANDING TEXTS AND VARIANTS</a></h2>
 
 <p class="msonormal1">Most scholars recognize the existence of four families of

--- a/text/part0000_split_010.html
+++ b/text/part0000_split_010.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection2">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_16"><a class="pcalibre pcalibre1" id="_Toc425418802"></a><a class="pcalibre pcalibre1" id="_Toc425418654"></a><a class="pcalibre pcalibre1" id="_Toc425418506">FOUNDATIONAL ENGLISH TEXT</a></h2>
 
 <p class="msonormal1">The EOB/NT project began as a revision of the WEB (<b class="calibre7">World

--- a/text/part0000_split_011.html
+++ b/text/part0000_split_011.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection2">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_17"><a class="pcalibre pcalibre1" id="_Toc425418803"></a><a class="pcalibre pcalibre1" id="_Toc425418655"></a><a class="pcalibre pcalibre1" id="_Toc425418507">CHURCH OFFICES</a></h2>
 
 <p class="msonormal1">The Greek words <span>dia,konoj</span>

--- a/text/part0000_split_012.html
+++ b/text/part0000_split_012.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection2">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_18"><a class="pcalibre pcalibre1" id="_Toc425418804"></a><a class="pcalibre pcalibre1" id="_Toc425418656"></a><a class="pcalibre pcalibre1" id="_Toc425418508">TEMPLE AND SANCTUARY</a></h2>
 
 <p class="msonormal1">Most translations fail to properly distinguish between <span>i`ero.n</span> (<i class="calibre4">hieron</i>) and <span>nao.j</span> (<i class="calibre4">naos</i>) which are both

--- a/text/part0000_split_013.html
+++ b/text/part0000_split_013.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection2">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_19"><a class="pcalibre pcalibre1" id="_Toc425418805"></a><a class="pcalibre pcalibre1" id="_Toc425418657"></a><a class="pcalibre pcalibre1" id="_Toc425418509">HELL AND HADES</a></h2>
 
 <p class="msonormal1">The King James Version caused lasting confusion by

--- a/text/part0000_split_014.html
+++ b/text/part0000_split_014.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection2">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_20"><a class="pcalibre pcalibre1" id="_Toc425418806"></a><a class="pcalibre pcalibre1" id="_Toc425418658"></a><a class="pcalibre pcalibre1" id="_Toc425418510">WORSHIP AND DIVINE SERVICE</a></h2>
 
 <p class="msonormal1">In modern English, “worship” (like prayer) has mainly taken

--- a/text/part0000_split_015.html
+++ b/text/part0000_split_015.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection2">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_21"><a class="pcalibre pcalibre1" id="_Toc425418807"></a><a class="pcalibre pcalibre1" id="_Toc425418659"></a><a class="pcalibre pcalibre1" id="_Toc425418511">KINGDOM</a></h2>
 
 <p class="msonormal1">It is normative to translate the Greek expression <span>basilei,a tou/ qeou/</span> as “Kingdom of

--- a/text/part0000_split_016.html
+++ b/text/part0000_split_016.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection2">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_22"><a class="pcalibre pcalibre1" id="_Toc425418808"></a><a class="pcalibre pcalibre1" id="_Toc425418660"></a><a class="pcalibre pcalibre1" id="_Toc425418512">PRONOUNS</a></h2>
 
 <p class="msonormal1">New Testament Greek can be confusing if subjects and pronouns

--- a/text/part0000_split_017.html
+++ b/text/part0000_split_017.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection2">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_23"><a class="pcalibre pcalibre1" id="_Toc425418809"></a><a class="pcalibre pcalibre1" id="_Toc425418661"></a><a class="pcalibre pcalibre1" id="_Toc425418513">PROPER NOUNS</a></h2>
 
 <p class="msonormal1">Hebrew names follow the now usual Masoretic style, except

--- a/text/part0000_split_018.html
+++ b/text/part0000_split_018.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection2">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_24"><a class="pcalibre pcalibre1" id="_Toc425418810"></a><a class="pcalibre pcalibre1" id="_Toc425418662"></a><a class="pcalibre pcalibre1" id="_Toc425418514">GENDER FORMS</a></h2>
 
 <p class="msonormal1">Many recent translations have gone to great length to

--- a/text/part0000_split_019.html
+++ b/text/part0000_split_019.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection2">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_25"><a class="pcalibre pcalibre1" id="_Toc425418811"></a><a class="pcalibre pcalibre1" id="_Toc425418663"></a><a class="pcalibre pcalibre1" id="_Toc425418515"><span class="calibre25">CAPITALIZATIONS</span></a><span class="calibre25"> </span></h2>
 
 <p class="msonormal1">Greek manuscripts do not have any capitalization. Hence, the

--- a/text/part0000_split_020.html
+++ b/text/part0000_split_020.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection2">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_26"><a class="pcalibre pcalibre1" id="_Toc425418812"></a><a class="pcalibre pcalibre1" id="_Toc425418664"></a><a class="pcalibre pcalibre1" id="_Toc425418516">SPIRIT</a><a title="" href="part0000_split_124.html#_edn22" class="pcalibre pcalibre1" id="_ednref22"><span class="msoendnotereference"><span class="msoendnotereference"><b class="calibre7"><span class="calibre34"><span class="calibre60">[22]</span></span></b></span></span></a></h2>
 
 <p class="msonormal1">The English word “spirit” (or “Spirit”) normally translates

--- a/text/part0000_split_021.html
+++ b/text/part0000_split_021.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection2">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_27"><a class="pcalibre pcalibre1" id="_Toc425418813"></a><a class="pcalibre pcalibre1" id="_Toc425418665"></a><a class="pcalibre pcalibre1" id="_Toc425418517"><span class="calibre25">THE ENGLISH PUNCTUATION</span></a></h2>
 
 <p class="msonormal1">The punctuation approach followed in the EOB/NT may seem

--- a/text/part0000_split_022.html
+++ b/text/part0000_split_022.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection2">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_28"><a class="pcalibre pcalibre1" id="_Toc425418814"></a><a class="pcalibre pcalibre1" id="_Toc425418666"></a><a class="pcalibre pcalibre1" id="_Toc425418518">AMEN, AMEN</a></h2>
 
 <p class="msonormal1">After due consideration, it was decided that the Lord’s form
@@ -19,7 +19,7 @@ into English rather than translated as “Most certainly,” “Truly, truly,”
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection3">
+<div class="section">
 
 <p class="msonormal1"> </p>
 

--- a/text/part0000_split_023.html
+++ b/text/part0000_split_023.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection3">
+<div class="section">
 <div class="calibre11">
 <p class="heading1b" id="calibre_pb_32"><a class="pcalibre pcalibre1" id="_Toc425418815"></a><a class="pcalibre pcalibre1" id="_Toc425418667"></a><a class="pcalibre pcalibre1" id="_Toc425418519"></a><a class="pcalibre pcalibre1" id="_Toc290636396"><span id="OK-53f1c2fa46e747eea0a124c9756c4a6f" class="calibre25">INTRODUCTION TO<br class="calibre6"/>
 THE SYNOPTIC GOSPELS AND ACTS</span></a></p>

--- a/text/part0000_split_024.html
+++ b/text/part0000_split_024.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection3">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_33"><a class="pcalibre pcalibre1" id="_Toc425418816"></a><a class="pcalibre pcalibre1" id="_Toc425418668"></a><a class="pcalibre pcalibre1" id="_Toc425418520">MATTHEW</a></h2>
 
 <p class="msonormal1"><b class="calibre7">Authorship/Date</b></p>

--- a/text/part0000_split_025.html
+++ b/text/part0000_split_025.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection3">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_34"><a class="pcalibre pcalibre1" id="_Toc425418817"></a><a class="pcalibre pcalibre1" id="_Toc425418669"></a><a class="pcalibre pcalibre1" id="_Toc425418521">MARK</a></h2>
 
 <p class="msonormal1"><b class="calibre7">Authorship/Date</b></p>

--- a/text/part0000_split_026.html
+++ b/text/part0000_split_026.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection3">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_35"><a class="pcalibre pcalibre1" id="_Toc425418818"></a><a class="pcalibre pcalibre1" id="_Toc425418670"></a><a class="pcalibre pcalibre1" id="_Toc425418522">LUKE AND ACTS</a></h2>
 
 <p class="msonormal1"><b class="calibre7">Authorship/Date</b></p>

--- a/text/part0000_split_027.html
+++ b/text/part0000_split_027.html
@@ -9,14 +9,14 @@
 
 <body lang="EN-US" link="blue" vlink="purple" class="calibre">
 
-  <div class="wordsection4">
+  <div class="section">
 
     <h1 class="calibre9" id="calibre_pb_41"><a class="pcalibre pcalibre1" id="_Toc425418819"></a><a class="pcalibre pcalibre1" id="_Toc425418671"></a><a class="pcalibre pcalibre1" id="_Toc425418523"></a><a class="pcalibre pcalibre1" id="_Toc290636397"><span id="R8-53f1c2fa46e747eea0a124c9756c4a6f" class="calibre25">(ACCORDING TO) MATTHEW</span> <br class="calibre6"/>
 </a><span class="calibre62">(</span><span class="calibre62">ΚΑΤΑ</span><span class="calibre62"> </span><span class="calibre62">ΜΑΤΘΑΙΟΝ</span><span class="calibre62">)</span></h1>
 
     <p class="sectiontopic">The Genealogy of Jesus</p>
 
-    <p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+    <p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
     <p class="msonormal1" id="toc_13">The book of the origins<a title="" href="part0000_split_124.html#_edn29" class="pcalibre pcalibre1" id="_ednref29"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[29]</span></span></span></a>
 of Jesus Christ,<a title="" href="part0000_split_124.html#_edn30" class="pcalibre pcalibre1" id="_ednref30"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[30]</span></span></span></a>
@@ -84,7 +84,7 @@ son; and he named him Jesus.</p>
 
     <p class="sectiontopic">The visit of the wise men (magi)</p>
 
-    <p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+    <p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
     <p class="msonormal1" id="toc_14">When Jesus was born in Bethlehem of Judea, in the days of
 King Herod, behold, wise men<a title="" href="part0000_split_124.html#_edn41" class="pcalibre pcalibre1" id="_ednref41"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[41]</span></span></span></a>
@@ -168,7 +168,7 @@ Nazareth, so that what had been spoken through the prophets might be fulfilled,
 
     <p class="sectiontopic">The ministry of John the Baptist</p>
 
-    <p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+    <p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
     <p class="msonormal1" id="toc_15">In those days, John the Baptizer was preaching in the
 wilderness of Judea, saying: <sup class="calibre31">2</sup>“Repent, for the Kingdom of Heaven is
@@ -218,7 +218,7 @@ behold, a voice from heaven said:<a title="" href="part0000_split_124.html#_edn6
 
     <p class="sectiontopic">The temptation in the desert wilderness</p>
 
-    <p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">4</p>
+    <p class="chapter-number chapter-number--nudge-2" id="toc_4">4</p>
 
     <p class="msonormal1" id="toc_16">Jesus was then led by the Spirit [to go] into the wilderness
 to be tempted by the devil. <sup class="calibre31">2</sup>When he had fasted forty days and forty
@@ -251,7 +251,7 @@ devil said to Jesus, “I will give you all of these things if you will fall dow
 and express adoration to<a title="" href="part0000_split_124.html#_edn69" class="pcalibre pcalibre1" id="_ednref69"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[69]</span></span></span></a>
 me.”</p>
 
-    <p class="msonormal1"><sup class="calibre31">10</sup>Then Jesus said to him, “Get behind me,<a title="" href="part0000_split_124.html#_edn70" class="pcalibre pcalibre1" id="_ednref70"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[70]</span></span></span></a>
+    <p class="msonormal1"><sup class="calibre31">10</sup>Then Jesus said to him, “Get behind me,<a title="" href="part0000_split_124.html#_edn70" class="pcalibre pcalibre1" id="_ednref70"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[70]</span></span></span></a>
 Satan! For it is written, ‘You shall express adoration to the Lord your God,
 and to him only shall you offer divine service.’”<a title="" href="part0000_split_124.html#_edn71" class="pcalibre pcalibre1" id="_ednref71"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[71]</span></span></span></a><a title="" href="part0000_split_124.html#_edn72" class="pcalibre pcalibre1" id="_ednref72"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[72]</span></span></span></a></p>
 
@@ -301,7 +301,7 @@ followed him.</p>
 
     <p class="sectiontopic">The sermon on the mount</p>
 
-    <p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_5">5</p>
+    <p class="chapter-number chapter-number--nudge-1-5" id="toc_5">5</p>
 
     <p class="msonormal1" id="toc_17">Seeing the crowds, Jesus<a title="" href="part0000_split_124.html#_edn76" class="pcalibre pcalibre1" id="_ednref76"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[76]</span></span></span></a>
 went up to the mountain and when he had sat down, his disciples came to him. <sup class="calibre31">2</sup>He
@@ -365,8 +365,8 @@ your good works and glorify your Father who is in heaven.</p>
 
     <p class="msonormal1"><sup class="calibre31">17</sup>Do not think that I came to destroy the law or
 the prophets. I did not come to destroy, but to fulfill! <sup class="calibre31">18</sup>Amen, I
-tell you: until heaven and earth pass away, not even one smallest letter<a title="" href="part0000_split_124.html#_edn83" class="pcalibre pcalibre1" id="_ednref83"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[83]</span></span></span></a>
-or one tiny pen stroke<a title="" href="part0000_split_124.html#_edn84" class="pcalibre pcalibre1" id="_ednref84"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[84]</span></span></span></a>
+tell you: until heaven and earth pass away, not even one smallest letter<a title="" href="part0000_split_124.html#_edn83" class="pcalibre pcalibre1" id="_ednref83"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[83]</span></span></span></a>
+or one tiny pen stroke<a title="" href="part0000_split_124.html#_edn84" class="pcalibre pcalibre1" id="_ednref84"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[84]</span></span></span></a>
 shall in any way pass away from the law, until all things are accomplished.<a title="" href="part0000_split_124.html#_edn85" class="pcalibre pcalibre1" id="_ednref85"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[85]</span></span></span></a>
 <sup class="calibre31">19</sup>Whoever, therefore, shall break one of these least commandments
 and teach others to do so shall be called least in the Kingdom of Heaven; but
@@ -378,12 +378,12 @@ Heaven.</p>
     <p class="sectiontopic">Anger</p>
 
     <p class="msonormal1"><sup class="calibre31">21</sup>You have heard that it was said of old, ‘You
-shall not murder;’<a title="" href="part0000_split_124.html#_edn86" class="pcalibre pcalibre1" id="_ednref86"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[86]</span></span></span></a>
+shall not murder;’<a title="" href="part0000_split_124.html#_edn86" class="pcalibre pcalibre1" id="_ednref86"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[86]</span></span></span></a>
 and ‘Whoever commits murder shall be in danger of the judgment.’ <sup class="calibre31">22</sup>But
-I tell you that whoever is angry with his brother without a cause<a title="" href="part0000_split_124.html#_edn87" class="pcalibre pcalibre1" id="_ednref87"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[87]</span></span></span></a>
-shall be in danger of the judgment. Whoever calls his brother ‘Raca!’<a title="" href="part0000_split_124.html#_edn88" class="pcalibre pcalibre1" id="_ednref88"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[88]</span></span></span></a>
+I tell you that whoever is angry with his brother without a cause<a title="" href="part0000_split_124.html#_edn87" class="pcalibre pcalibre1" id="_ednref87"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[87]</span></span></span></a>
+shall be in danger of the judgment. Whoever calls his brother ‘Raca!’<a title="" href="part0000_split_124.html#_edn88" class="pcalibre pcalibre1" id="_ednref88"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[88]</span></span></span></a>
 shall be answerable to the Sanhedrin; and whoever shall say, ‘You fool!’ shall
-be in danger of the fire of Gehenna.<a title="" href="part0000_split_124.html#_edn89" class="pcalibre pcalibre1" id="_ednref89"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[89]</span></span></span></a></p>
+be in danger of the fire of Gehenna.<a title="" href="part0000_split_124.html#_edn89" class="pcalibre pcalibre1" id="_ednref89"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[89]</span></span></span></a></p>
 
     <p class="msonormal1"> <sup class="calibre31">23</sup>If therefore you are offering your gift at the
 altar and there remember that your brother has anything against you, <sup class="calibre31">24</sup>leave
@@ -392,13 +392,13 @@ brother, and then offer your gift. <sup class="calibre31">25</sup>Find an agreem
 adversary as soon as possible, even as you are on your way to court, fearing
 that perhaps the prosecutor will deliver you to the judge, the judge deliver
 you to the officer, and you may be thrown into prison. <sup class="calibre31">26</sup>Amen, I
-tell you: you will not get out of there until you have paid the last penny.<a title="" href="part0000_split_124.html#_edn90" class="pcalibre pcalibre1" id="_ednref90"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[90]</span></span></span></a></p>
+tell you: you will not get out of there until you have paid the last penny.<a title="" href="part0000_split_124.html#_edn90" class="pcalibre pcalibre1" id="_ednref90"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[90]</span></span></span></a></p>
 
     <p class="sectiontopic">Adultery and divorce</p>
 
     <p class="msonormal1"><sup class="calibre31">27</sup>You have heard that it was said to the
-ancients,<a title="" href="part0000_split_124.html#_edn91" class="pcalibre pcalibre1" id="_ednref91"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[91]</span></span></span></a>
-‘You shall not commit adultery;’<a title="" href="part0000_split_124.html#_edn92" class="pcalibre pcalibre1" id="_ednref92"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[92]</span></span></span></a>
+ancients,<a title="" href="part0000_split_124.html#_edn91" class="pcalibre pcalibre1" id="_ednref91"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[91]</span></span></span></a>
+‘You shall not commit adultery;’<a title="" href="part0000_split_124.html#_edn92" class="pcalibre pcalibre1" id="_ednref92"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[92]</span></span></span></a>
 <sup class="calibre31">28</sup>but I tell you that anyone who gazes at a woman with a view to
 lust<a title="" href="part0000_split_124.html#_edn93" class="pcalibre pcalibre1" id="_ednref93"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[93]</span></span></span></a>
 after her has already committed adultery with her in his heart. <sup class="calibre31">29</sup>If
@@ -410,7 +410,7 @@ for you that one of your members should perish, than for your whole body to be
 cast into Gehenna.</p>
 
     <p class="msonormal1"><sup class="calibre31">31</sup>It was also said, ‘Whoever shall divorce<a title="" href="part0000_split_124.html#_edn94" class="pcalibre pcalibre1" id="_ednref94"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[94]</span></span></span></a>
-his wife, let him give her a certificate of divorce,’<a title="" href="part0000_split_124.html#_edn95" class="pcalibre pcalibre1" id="_ednref95"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[95]</span></span></span></a>
+his wife, let him give her a certificate of divorce,’<a title="" href="part0000_split_124.html#_edn95" class="pcalibre pcalibre1" id="_ednref95"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[95]</span></span></span></a>
 <sup class="calibre31">32</sup>but I tell you that whoever divorces his wife (except for the case
 of sexual immorality), makes her an adulteress; and whoever marries a woman put
 away in this manner commits adultery.</p>
@@ -429,7 +429,7 @@ Whatever goes beyond these is from the evil one.</p>
     <p class="sectiontopic">Retaliation and love for one’s enemies</p>
 
     <p class="msonormal1"><sup class="calibre31">38</sup>You have heard that it was said, ‘An eye for an
-eye, and a tooth for a tooth.’<a title="" href="part0000_split_124.html#_edn96" class="pcalibre pcalibre1" id="_ednref96"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[96]</span></span></span></a>
+eye, and a tooth for a tooth.’<a title="" href="part0000_split_124.html#_edn96" class="pcalibre pcalibre1" id="_ednref96"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[96]</span></span></span></a>
 <sup class="calibre31">39</sup>But I tell you: do not resist one who is evil, but to whoever
 strikes you on your right cheek, present the other cheek as well. <sup class="calibre31">40</sup>If
 anyone sues you to take away your tunic, let him have your cloak also. <sup class="calibre31">41</sup>Whoever
@@ -437,21 +437,21 @@ compels you to go one mile, go with him for two. <sup class="calibre31">42</sup>
 asks you, and do not deny whoever desires to borrow from you.</p>
 
     <p class="msonormal1"><sup class="calibre31">43</sup>You have heard that it was said, ‘You shall
-love your neighbor,<a title="" href="part0000_split_124.html#_edn97" class="pcalibre pcalibre1" id="_ednref97"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[97]</span></span></span></a>
-and hate your enemy.<a title="" href="part0000_split_124.html#_edn98" class="pcalibre pcalibre1" id="_ednref98"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[98]</span></span></span></a>’
+love your neighbor,<a title="" href="part0000_split_124.html#_edn97" class="pcalibre pcalibre1" id="_ednref97"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[97]</span></span></span></a>
+and hate your enemy.<a title="" href="part0000_split_124.html#_edn98" class="pcalibre pcalibre1" id="_ednref98"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[98]</span></span></span></a>’
 <sup class="calibre31">44</sup>But I tell you: love your enemies, bless those who curse you, do
 good to those who hate you! Pray for those who mistreat you and persecute you, <sup class="calibre31">45</sup>so
 that you may be children of your Father who is in heaven. For he makes his sun
 to rise on the evil and the good, and he sends rain on the just and the unjust.
 <sup class="calibre31">46</sup>And so, if you love those who love you, what reward do you have?
 Do not even the tax collectors do the same? <sup class="calibre31">47</sup>If you only greet your
-friends, what more do you do than others? Do not even the tax collectors<a title="" href="part0000_split_124.html#_edn99" class="pcalibre pcalibre1" id="_ednref99"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[99]</span></span></span></a>
+friends, what more do you do than others? Do not even the tax collectors<a title="" href="part0000_split_124.html#_edn99" class="pcalibre pcalibre1" id="_ednref99"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[99]</span></span></span></a>
 do the same? <sup class="calibre31">48</sup>Therefore, be perfect, just as your Father in heaven
 is perfect.</p>
 
     <p class="sectiontopic">Almsgiving</p>
 
-    <p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_6">6</p>
+    <p class="chapter-number chapter-number--nudge-1-5" id="toc_6">6</p>
 
     <p class="msonormal1" id="toc_18">Be careful not to make your charitable giving<a title="" href="part0000_split_124.html#_edn100" class="pcalibre pcalibre1" id="_ednref100"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[100]</span></span></span></a>
 before other people, with the intention to be seen by them. If you do so, you
@@ -501,7 +501,7 @@ him.<a title="" href="part0000_split_124.html#_edn105" class="pcalibre pcalibre1
   bread and <sup class="calibre31">12</sup>forgive us our debts as we also forgive our debtors. <sup class="calibre31">13</sup>Do
   not bring us to a period of trial, but deliver us from the evil one.<br class="calibre6"/>
   &lt;For yours is the Kingdom, the power, and the glory, <br class="calibre6"/>
-  now and unto ages of ages. Amen&gt;.<a title="" href="part0000_split_124.html#_edn107" class="pcalibre pcalibre1" id="_ednref107"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[107]</span></span></span></a></p>
+  now and unto ages of ages. Amen&gt;.<a title="" href="part0000_split_124.html#_edn107" class="pcalibre pcalibre1" id="_ednref107"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[107]</span></span></span></a></p>
         </td>
         <td width="223" valign="top" class="calibre66">
           <p class="msonormal11">‘Our Father who are (art)
@@ -515,7 +515,7 @@ him.<a title="" href="part0000_split_124.html#_edn105" class="pcalibre pcalibre1
   <sup class="calibre31">13</sup>And lead us not into temptation, <br class="calibre6"/>
   but deliver us from the evil one.<br class="calibre6"/>
   For yours (thine) is the Kingdom, the power, and the glory, <br class="calibre6"/>
-  now and unto ages of ages. Amen.<a title="" href="part0000_split_124.html#_edn109" class="pcalibre pcalibre1" id="_ednref109"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[109]</span></span></span></a></p>
+  now and unto ages of ages. Amen.<a title="" href="part0000_split_124.html#_edn109" class="pcalibre pcalibre1" id="_ednref109"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[109]</span></span></span></a></p>
         </td>
       </tr>
 
@@ -560,7 +560,7 @@ the sky: they do not sow, or reap, or gather into barns. Your heavenly Father
 feeds them! Are you not of much more value than they?</p>
 
     <p class="msonormal1"><sup class="calibre31">27</sup>Which of you, by being anxious, can add one
-moment<a title="" href="part0000_split_124.html#_edn113" class="pcalibre pcalibre1" id="_ednref113"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[113]</span></span></span></a>
+moment<a title="" href="part0000_split_124.html#_edn113" class="pcalibre pcalibre1" id="_ednref113"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[113]</span></span></span></a>
 to his lifespan? <sup class="calibre31">28</sup>Why then are you anxious about clothing? Consider
 the lilies of the field, how they grow. They do not toil or spin, <sup class="calibre31">29</sup>yet
 I tell you that even Solomon in all his glory was not dressed like one of these!
@@ -579,7 +579,7 @@ of its own.</p>
 
     <p class="sectiontopic">Judging others—‘Pearls offered to swine’</p>
 
-    <p class="style35ptloweredby1ptlinespacingexactly2445pt" id="toc_7">7</p>
+    <p class="chapter-number chapter-number--nudge-1" id="toc_7">7</p>
 
     <p class="msonormal1" id="toc_19">Do not judge in order not to be judged. <sup class="calibre31">2</sup>For in
 the same way that you judge others, you will be judged, and with the measure that
@@ -611,7 +611,7 @@ prophets.</p>
 
     <p class="msonormal1"><sup class="calibre31">13</sup>Enter by the narrow gate, for wide is the gate
 and broad is the way<a title="" href="part0000_split_124.html#_edn117" class="pcalibre pcalibre1" id="_ednref117"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[117]</span></span></span></a>
-that leads to destruction, and many are those who enter by it. <sup class="calibre31">14</sup>How<a title="" href="part0000_split_124.html#_edn118" class="pcalibre pcalibre1" id="_ednref118"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[118]</span></span></span></a>
+that leads to destruction, and many are those who enter by it. <sup class="calibre31">14</sup>How<a title="" href="part0000_split_124.html#_edn118" class="pcalibre pcalibre1" id="_ednref118"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[118]</span></span></span></a>
 narrow is the gate, and how pressing<a title="" href="part0000_split_124.html#_edn119" class="pcalibre pcalibre1" id="_ednref119"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[119]</span></span></span></a>
 is the way that leads to life! Few are those who find it.</p>
 
@@ -648,7 +648,7 @@ he taught them with authority, not like the scribes.</p>
 
     <p class="sectiontopic">Healing of a leper</p>
 
-    <p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_8">8</p>
+    <p class="chapter-number chapter-number--nudge-1-5" id="toc_8">8</p>
 
     <p class="msonormal1" id="toc_20">When Jesus came down from the mountain, great multitudes
 followed him. <sup class="calibre31">2</sup>Behold, a leper came to him and expressed adoration
@@ -746,7 +746,7 @@ would depart from their borders.</p>
 
     <p class="sectiontopic">The healing of a paralytic</p>
 
-    <p class="style365ptloweredby1ptlinespacingexactly2445pt" id="toc_9">9</p>
+    <p class="chapter-number chapter-number--nudge-1" id="toc_9">9</p>
 
     <p class="msonormal1" id="toc_21">Jesus entered into a boat, crossed over [the lake] and came
 into his own town. <sup class="calibre31">2</sup>Behold, some people brought him a man who was
@@ -778,8 +778,8 @@ tax collectors and sinners?”</p>
 
     <p class="msonormal1"><sup class="calibre31">12</sup>When Jesus heard it, he told them, “Those who
 are healthy have no need for a physician, but those who are sick do. <sup class="calibre31">13</sup>But
-go and learn what this means: ‘I desire mercy, and not sacrifice,’<a title="" href="part0000_split_124.html#_edn132" class="pcalibre pcalibre1" id="_ednref132"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[132]</span></span></span></a>
-for I did not come to call the righteous but sinners to repentance.<a title="" href="part0000_split_124.html#_edn133" class="pcalibre pcalibre1" id="_ednref133"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[133]</span></span></span></a>”</p>
+go and learn what this means: ‘I desire mercy, and not sacrifice,’<a title="" href="part0000_split_124.html#_edn132" class="pcalibre pcalibre1" id="_ednref132"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[132]</span></span></span></a>
+for I did not come to call the righteous but sinners to repentance.<a title="" href="part0000_split_124.html#_edn133" class="pcalibre pcalibre1" id="_ednref133"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[133]</span></span></span></a>”</p>
 
     <p class="sectiontopic">About fasting—The old and new</p>
 
@@ -857,7 +857,7 @@ therefore that the Lord of the harvest will send out workers into his harvest.�
 
     <p class="sectiontopic">The commission of the Twelve</p>
 
-    <p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_10">10</p>
+    <p class="chapter-number chapter-number--nudge-1-5" id="toc_10">10</p>
 
     <p class="msonormal1" id="toc_22"><span class="calibre27">Jesus<a title="" href="part0000_split_124.html#_edn140" class="pcalibre pcalibre1" id="_ednref140"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre30">[140]</span></span></span></a> called to himself his
 twelve disciples and gave them authority over unclean spirits, to cast them
@@ -874,7 +874,7 @@ and Judas Iscariot, who also betrayed him.</span></p>
 instruction: “Do not go among the Gentiles and do not enter into any city of
 the Samaritans. <sup class="calibre31">6</sup>Rather, go to the lost sheep of the house of
 Israel. <sup class="calibre31">7</sup>As you go, preach and say: ‘The Kingdom of Heaven is at
-hand!’ <sup class="calibre31">8</sup>Heal the sick, cleanse the lepers, raise the dead<a title="" href="part0000_split_124.html#_edn144" class="pcalibre pcalibre1" id="_ednref144"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[144]</span></span></span></a>,
+hand!’ <sup class="calibre31">8</sup>Heal the sick, cleanse the lepers, raise the dead<a title="" href="part0000_split_124.html#_edn144" class="pcalibre pcalibre1" id="_ednref144"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[144]</span></span></span></a>,
 and cast out demons. Freely you have received, give freely as well. <sup class="calibre31">9</sup>Do
 not take any gold, silver or brass in your money belts. <sup class="calibre31">10</sup>Do not take
 a bag for your journey, or two coats, or shoes, or staff: the one who works is
@@ -915,9 +915,9 @@ of them, for there is nothing covered that will not be revealed and nothing hidd
 that will not be known. <sup class="calibre31">27</sup>What I tell you in the darkness, speak in
 the light; and what you hear whispered in the ear, proclaim on the housetops. <sup class="calibre31">28</sup>Do
 not be afraid of those who [can] kill the body but are not able to kill the
-soul. Rather, fear him who is able to destroy both soul and body in Gehenna.<a title="" href="part0000_split_124.html#_edn148" class="pcalibre pcalibre1" id="_ednref148"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[148]</span></span></span></a></p>
+soul. Rather, fear him who is able to destroy both soul and body in Gehenna.<a title="" href="part0000_split_124.html#_edn148" class="pcalibre pcalibre1" id="_ednref148"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[148]</span></span></span></a></p>
 
-    <p class="msonormal1"><sup class="calibre31">29</sup>Are not two sparrows sold for a small coin<a title="" href="part0000_split_124.html#_edn149" class="pcalibre pcalibre1" id="_ednref149"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[149]</span></span></span></a>?
+    <p class="msonormal1"><sup class="calibre31">29</sup>Are not two sparrows sold for a small coin<a title="" href="part0000_split_124.html#_edn149" class="pcalibre pcalibre1" id="_ednref149"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[149]</span></span></span></a>?
 Not one of them falls on the ground apart from your Father’s will, <sup class="calibre31">30</sup>but
 the very hairs of your head are all numbered. <sup class="calibre31">31</sup>Therefore, do not be
 afraid! You are of more value than many sparrows! <sup class="calibre31">32</sup>Whoever confesses
@@ -931,7 +931,7 @@ in heaven.</p>
 earth! I did not come to bring peace, but a sword. <sup class="calibre31">35</sup>Indeed, I came
 to set a son against his father, a daughter against her mother and a daughter-in-law
 against her mother-in-law. <sup class="calibre31">36</sup>A man’s enemies will be members<a title="" href="part0000_split_124.html#_edn150" class="pcalibre pcalibre1" id="_ednref150"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[150]</span></span></span></a>
-of his own household.<a title="" href="part0000_split_124.html#_edn151" class="pcalibre pcalibre1" id="_ednref151"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[151]</span></span></span></a></p>
+of his own household.<a title="" href="part0000_split_124.html#_edn151" class="pcalibre pcalibre1" id="_ednref151"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[151]</span></span></span></a></p>
 
     <p class="sectiontopic">Requirements for discipleship—Rewards</p>
 
@@ -950,7 +950,7 @@ he is a disciple will in no way lose his reward.”</p>
     <p class="sectiontopic">Message from John the Baptist—The Lord bears witness to
 John</p>
 
-    <p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_11">11</p>
+    <p class="chapter-number chapter-number--nudge-2" id="toc_11">11</p>
 
     <p class="msonormal1" id="toc_23">When Jesus had finished giving instructions to his twelve
 disciples, he left that place to teach and preach in their cities.</p>
@@ -962,8 +962,8 @@ we look for another?”</p>
 
     <p class="msonormal1"><sup class="calibre31">4</sup>Jesus replied to them, “Go and tell John about the
 things you hear and see: <sup class="calibre31">5</sup>the blind receive their sight, the lame
-walk, the lepers are cleansed, the deaf hear,<a title="" href="part0000_split_124.html#_edn154" class="pcalibre pcalibre1" id="_ednref154"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[154]</span></span></span></a>
-the dead are raised up and the poor have Good News preached to them.<a title="" href="part0000_split_124.html#_edn155" class="pcalibre pcalibre1" id="_ednref155"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[155]</span></span></span></a>
+walk, the lepers are cleansed, the deaf hear,<a title="" href="part0000_split_124.html#_edn154" class="pcalibre pcalibre1" id="_ednref154"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[154]</span></span></span></a>
+the dead are raised up and the poor have Good News preached to them.<a title="" href="part0000_split_124.html#_edn155" class="pcalibre pcalibre1" id="_ednref155"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[155]</span></span></span></a>
 <sup class="calibre31">6</sup>Blessed is he who finds no occasion for stumbling in me.”</p>
 
     <p class="msonormal1"><sup class="calibre31">7</sup>As they went their way, Jesus began to speak to
@@ -975,14 +975,14 @@ much more than a prophet! <sup class="calibre31">10</sup>Indeed, he is the one o
 written:</p>
 
     <p class="poetry1cxspfirst">Behold, I send my messenger before your face,<a title="" href="part0000_split_124.html#_edn157" class="pcalibre pcalibre1" id="_ednref157"><span class="msoendnotereference"><span class="msoendnotereference"><b class="calibre7"><span class="calibre28">[157]</span></b></span></span></a>
-who will prepare your way before you.<a title="" href="part0000_split_124.html#_edn158" class="pcalibre pcalibre1" id="_ednref158"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><b class="calibre7"><span class="calibre28">[158]</span></b></span></span></a>
+who will prepare your way before you.<a title="" href="part0000_split_124.html#_edn158" class="pcalibre pcalibre1" id="_ednref158"><span class="footnote-ref"><span class="footnote-ref"><b class="calibre7"><span class="calibre28">[158]</span></b></span></span></a>
 </p>
 
     <p class="msonormal1"><sup class="calibre31">11</sup>Amen, I tell you: among those born of women,
 there has not arisen anyone greater than John the Baptizer! Yet the least in
 the Kingdom of Heaven is greater than he. <sup class="calibre31">12</sup>From the days of John
 the Baptizer until now, the Kingdom of Heaven suffers violence, and the violent<a title="" href="part0000_split_124.html#_edn159" class="pcalibre pcalibre1" id="_ednref159"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[159]</span></span></span></a>
-take it by force.<a title="" href="part0000_split_124.html#_edn160" class="pcalibre pcalibre1" id="_ednref160"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[160]</span></span></span></a>
+take it by force.<a title="" href="part0000_split_124.html#_edn160" class="pcalibre pcalibre1" id="_ednref160"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[160]</span></span></span></a>
 <sup class="calibre31">13</sup>For all the prophets and the law prophesied until John [came]. <sup class="calibre31">14</sup>If
 you are willing to accept it, this [John] is Elias (Elijah) who was to come. <sup class="calibre31">15</sup>Anyone
 who has ears for listening should listen!</p>
@@ -994,7 +994,7 @@ you did not lament!’ <sup class="calibre31">18</sup>As it is, John came neithe
 drinking, and so they say, ‘He has a demon!’ <sup class="calibre31">19</sup>The Son of Man came
 eating and drinking, and so they say, ‘Behold, a glutton and a drunkard, a friend
 of tax collectors and sinners!’ Nevertheless, Wisdom is justified by her
-children!”<a title="" href="part0000_split_124.html#_edn161" class="pcalibre pcalibre1" id="_ednref161"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[161]</span></span></span></a></p>
+children!”<a title="" href="part0000_split_124.html#_edn161" class="pcalibre pcalibre1" id="_ednref161"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[161]</span></span></span></a></p>
 
     <p class="sectiontopic">Woe to Chorazin and Bethsaida</p>
 
@@ -1030,7 +1030,7 @@ rest for your souls.<a title="" href="part0000_split_124.html#_edn164" class="pc
 
     <p class="sectiontopic">About the Sabbath—The Lord of the Sabbath</p>
 
-    <p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_24">12</p>
+    <p class="chapter-number chapter-number--nudge-2" id="toc_24">12</p>
 
     <p class="msonormal1" id="toc_12">At that time, on the Sabbath day, Jesus was going through
 grain fields. Being hungry, his disciples began to pluck heads of grain and to
@@ -1040,11 +1040,11 @@ your disciples are doing what is not lawful to do on the Sabbath!”</p>
     <p class="msonormal1"><sup class="calibre31">3</sup>But Jesus replied, “Have you not read what David
 did, when he and those who were with him were hungry? <sup class="calibre31">4</sup>He entered
 into the house of God and ate the bread of the Presence,<a title="" href="part0000_split_124.html#_edn165" class="pcalibre pcalibre1" id="_ednref165"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[165]</span></span></span></a>
-which was not lawful for him to eat, but only for the priests?<a title="" href="part0000_split_124.html#_edn166" class="pcalibre pcalibre1" id="_ednref166"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[166]</span></span></span></a>
+which was not lawful for him to eat, but only for the priests?<a title="" href="part0000_split_124.html#_edn166" class="pcalibre pcalibre1" id="_ednref166"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[166]</span></span></span></a>
 <sup class="calibre31">5</sup>Or have you not read in the law, that on the Sabbath day, the
 priests in the temple profane the Sabbath, and yet remain without guilt?<a title="" href="part0000_split_124.html#_edn167" class="pcalibre pcalibre1" id="_ednref167"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[167]</span></span></span></a>
 <sup class="calibre31">6</sup>But I tell you that someone greater than the temple is here! <sup class="calibre31">7</sup>If
-you had known what this means, ‘I desire mercy, and not sacrifice,’<a title="" href="part0000_split_124.html#_edn168" class="pcalibre pcalibre1" id="_ednref168"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[168]</span></span></span></a>
+you had known what this means, ‘I desire mercy, and not sacrifice,’<a title="" href="part0000_split_124.html#_edn168" class="pcalibre pcalibre1" id="_ednref168"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[168]</span></span></span></a>
 you would not have condemned the innocent. <sup class="calibre31">8</sup>For the Son of Man is
 Lord even of the Sabbath.”</p>
 
@@ -1125,7 +1125,7 @@ or make the tree corrupt and its fruit [will be] corrupt, for the tree is known
 by its fruit. <sup class="calibre31">34</sup>You offspring of vipers, how can you, being evil,
 speak good things? Indeed, words flow out of what fills the heart.<a title="" href="part0000_split_124.html#_edn178" class="pcalibre pcalibre1" id="_ednref178"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[178]</span></span></span></a>
 <sup class="calibre31">35</sup>The good man brings out good things from his good treasure, and
-the evil man brings out evil things from his evil treasure<a title="" href="part0000_split_124.html#_edn179" class="pcalibre pcalibre1" id="_ednref179"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[179]</span></span></span></a>.
+the evil man brings out evil things from his evil treasure<a title="" href="part0000_split_124.html#_edn179" class="pcalibre pcalibre1" id="_ednref179"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[179]</span></span></span></a>.
 <sup class="calibre31">36</sup>I tell you that for every idle word that people speak, they will
 give an account of it in the day of judgment. <sup class="calibre31">37</sup>For by your words
 you will be justified, and by your words you will be condemned.”</p>
@@ -1174,7 +1174,7 @@ heaven is my brother, and sister, and mother.”</p>
 
     <p class="sectiontopic">The parable of the sower</p>
 
-    <p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_25">13</p>
+    <p class="chapter-number chapter-number--nudge-1-5" id="toc_25">13</p>
 
     <p class="msonormal1">On that day, Jesus went out of the house and sat down by the
 seaside. <sup class="calibre31">2</sup>Since great crowds had gathered to [listen to] him, he
@@ -1250,7 +1250,7 @@ times as much, some sixty, and some thirty times as much.”</p>
 
     <p class="msonormal1"><sup class="calibre31">24</sup>He also presented them another parable in these
 words, “The Kingdom of Heaven is like a man who sowed good seed in his field. <sup class="calibre31">25</sup>While
-people slept, his enemy came and also sowed weed grass<a title="" href="part0000_split_124.html#_edn187" class="pcalibre pcalibre1" id="_ednref187"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[187]</span></span></span></a>
+people slept, his enemy came and also sowed weed grass<a title="" href="part0000_split_124.html#_edn187" class="pcalibre pcalibre1" id="_ednref187"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[187]</span></span></span></a>
 among the wheat, and went away. <sup class="calibre31">26</sup>But when the wheat sprang up and
 brought forth fruit, the weeds also appeared. <sup class="calibre31">27</sup>The slaves of the
 householder came [forward] and said to him, ‘Sir,<a title="" href="part0000_split_124.html#_edn188" class="pcalibre pcalibre1" id="_ednref188"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[188]</span></span></span></a>
@@ -1355,7 +1355,7 @@ deeds of power there because of their unbelief.<a title="" href="part0000_split_
 
     <p class="sectiontopic">Herod and the beheading of John the Baptist</p>
 
-    <p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_26">14</p>
+    <p class="chapter-number chapter-number--nudge-2" id="toc_26">14</p>
 
     <p class="msonormal1">At that time, Herod the tetrarch heard the report concerning
 Jesus, <sup class="calibre31">2</sup>and he said to his servants, “This is John the Baptist! He
@@ -1415,7 +1415,7 @@ the fourth watch of the night,<a title="" href="part0000_split_124.html#_edn201"
 Jesus came to them, walking on the sea.<a title="" href="part0000_split_124.html#_edn202" class="pcalibre pcalibre1" id="_ednref202"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[202]</span></span></span></a>
 <sup class="calibre31">26</sup>When the disciples saw him walking on the sea, they were troubled<a title="" href="part0000_split_124.html#_edn203" class="pcalibre pcalibre1" id="_ednref203"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[203]</span></span></span></a>
 and said, “It is a ghost!” and they cried out in fear. <sup class="calibre31">27</sup>But at
-once, Jesus spoke to them, saying “Take heart! It is I!<a title="" href="part0000_split_124.html#_edn204" class="pcalibre pcalibre1" id="_ednref204"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[204]</span></span></span></a>
+once, Jesus spoke to them, saying “Take heart! It is I!<a title="" href="part0000_split_124.html#_edn204" class="pcalibre pcalibre1" id="_ednref204"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[204]</span></span></span></a>
 Do not be afraid.”</p>
 
     <p class="msonormal1"><sup class="calibre31">28</sup>Peter answered him and said, “Lord, if it is
@@ -1445,7 +1445,7 @@ of his garment, and all those who touched it were healed.</p>
 
     <p class="sectiontopic">About traditions that nullify the word of God</p>
 
-    <p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_27">15</p>
+    <p class="chapter-number chapter-number--nudge-1-5" id="toc_27">15</p>
 
     <p class="msonormal1">Scribes and Pharisees then came to Jesus from Jerusalem,
 saying: <sup class="calibre31">2</sup>“Why do your disciples disobey the tradition of the
@@ -1453,8 +1453,8 @@ presbyters? For they do not wash their hands when they eat bread.”</p>
 
     <p class="msonormal1"><sup class="calibre31">3</sup>Jesus answered them, “Why do you also disobey
 the commandment of God because of your tradition? <sup class="calibre31">4</sup>For God commanded,
-‘Honor your father and your mother,’<a title="" href="part0000_split_124.html#_edn208" class="pcalibre pcalibre1" id="_ednref208"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[208]</span></span></span></a>
-and, ‘Whoever speaks evil of father or mother should be put to death.’<a title="" href="part0000_split_124.html#_edn209" class="pcalibre pcalibre1" id="_ednref209"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[209]</span></span></span></a>
+‘Honor your father and your mother,’<a title="" href="part0000_split_124.html#_edn208" class="pcalibre pcalibre1" id="_ednref208"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[208]</span></span></span></a>
+and, ‘Whoever speaks evil of father or mother should be put to death.’<a title="" href="part0000_split_124.html#_edn209" class="pcalibre pcalibre1" id="_ednref209"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[209]</span></span></span></a>
 <sup class="calibre31">5</sup>But you say, ‘Anyone may tell his father or his mother, “Whatever support<a title="" href="part0000_split_124.html#_edn210" class="pcalibre pcalibre1" id="_ednref210"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[210]</span></span></span></a>
 you might otherwise have received from me is now a gift devoted to God,” and is
 not bound to honor his father or mother.’<a title="" href="part0000_split_124.html#_edn211" class="pcalibre pcalibre1" id="_ednref211"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[211]</span></span></span></a>

--- a/text/part0000_split_028.html
+++ b/text/part0000_split_028.html
@@ -7,11 +7,11 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection4">
+<div class="section">
 <p class="sectiontopic">Seeking after a sign—The yeast or leaven of the Pharisees
 and Sadducees </p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_1">16</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_1">16</p>
 
 <p class="msonormal1">The Pharisees and Sadducees came and put Jesus to the test
 by asking him to show them a sign<a title="" href="part0000_split_124.html#_edn222" class="pcalibre pcalibre1" id="_ednref222"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[222]</span></span></span></a>
@@ -61,9 +61,9 @@ Son of the living God!”</p>
 <p class="msonormal1"><sup class="calibre31">17</sup>And Jesus answered him, “Blessed are you,<a title="" href="part0000_split_124.html#_edn225" class="pcalibre pcalibre1" id="_ednref225"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[225]</span></span></span></a>
 Simon Bar<a title="" href="part0000_split_124.html#_edn226" class="pcalibre pcalibre1" id="_ednref226"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[226]</span></span></span></a>
 Jonah, for flesh and blood has not revealed this to you, but my Father who is
-in heaven. <sup class="calibre31">18</sup>I also tell you that you are Peter,<a title="" href="part0000_split_124.html#_edn227" class="pcalibre pcalibre1" id="_ednref227"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[227]</span></span></span></a>
+in heaven. <sup class="calibre31">18</sup>I also tell you that you are Peter,<a title="" href="part0000_split_124.html#_edn227" class="pcalibre pcalibre1" id="_ednref227"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[227]</span></span></span></a>
 and upon this rock I will build my Church,<a title="" href="part0000_split_124.html#_edn228" class="pcalibre pcalibre1" id="_ednref228"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[228]</span></span></span></a>
-and the gates of hades<a title="" href="part0000_split_124.html#_edn229" class="pcalibre pcalibre1" id="_ednref229"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[229]</span></span></span></a>
+and the gates of hades<a title="" href="part0000_split_124.html#_edn229" class="pcalibre pcalibre1" id="_ednref229"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[229]</span></span></span></a>
 will not prevail against it. <sup class="calibre31">19</sup>I will give you the keys of the Kingdom
 of Heaven, and whatever you bind on earth will be bound in heaven; and whatever
 you loose on earth will be loosed in heaven.” <sup class="calibre31">20</sup>Then he commanded
@@ -95,7 +95,7 @@ Man coming in his Kingdom.”<a title="" href="part0000_split_124.html#_edn232" 
 
 <p class="sectiontopic">The Lord’s transfiguration—The coming of Elias</p>
 
-<p class="style35ptloweredby1ptlinespacingexactly2445pt" id="toc_2">17</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_2">17</p>
 
 <p class="msonormal1">Six days later, Jesus took with him Peter, James, and John
 his brother, and he brought them up into a high mountain by themselves. <sup class="calibre31">2</sup>[There],
@@ -173,13 +173,13 @@ toll or tribute? From their children, or from foreigners?”<a title="" href="pa
 <p class="msonormal1">Jesus said to him, “Therefore, the children are exempt. <sup class="calibre31">27</sup>But
 in order not to cause them to stumble, go to the sea, cast a hook, and take up
 the first fish that comes up. When you have opened its mouth, you will find a
-stater coin.<a title="" href="part0000_split_124.html#_edn243" class="pcalibre pcalibre1" id="_ednref243"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[243]</span></span></span></a>
+stater coin.<a title="" href="part0000_split_124.html#_edn243" class="pcalibre pcalibre1" id="_ednref243"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[243]</span></span></span></a>
 Take it, and give it to them for me and you.”</p>
 
 <p class="sectiontopic">Like a child—Greatest in the Kingdom—Causing little ones
 to sin</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_3">18</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">18</p>
 
 <p class="msonormal1">At that time, the disciples came to Jesus and asked, “Who
 then is greatest in the Kingdom of Heaven?”</p>
@@ -201,7 +201,7 @@ stumble, cut them off and throw them away from you! It is better for you to
 enter into life crippled or maimed rather than to have two hands or two feet and
 yet be cast into eternal fire. <sup class="calibre31">9</sup>If your eye causes you to stumble,
 pluck it out and throw it away from you. It is better for you to enter into
-life with one eye, rather than to be cast into the Gehenna<a title="" href="part0000_split_124.html#_edn244" class="pcalibre pcalibre1" id="_ednref244"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[244]</span></span></span></a>
+life with one eye, rather than to be cast into the Gehenna<a title="" href="part0000_split_124.html#_edn244" class="pcalibre pcalibre1" id="_ednref244"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[244]</span></span></span></a>
 of fire having two eyes. <sup class="calibre31">10</sup>Do not despise any of these little ones,
 for I tell you that in heaven, their angels always see the face of my Father
 who is in heaven.</p>
@@ -225,7 +225,7 @@ the Church</p>
 go, show him his fault between you and him alone. If he listens to you, you
 have gained back your brother! <sup class="calibre31">16</sup>But if he does not listen, take one
 or two more with you, so that at the mouth of two or three witnesses every word
-may be established.<a title="" href="part0000_split_124.html#_edn248" class="pcalibre pcalibre1" id="_ednref248"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[248]</span></span></span></a>
+may be established.<a title="" href="part0000_split_124.html#_edn248" class="pcalibre pcalibre1" id="_ednref248"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[248]</span></span></span></a>
 <sup class="calibre31">17</sup>If he refuses to listen to them, tell it to the Church. If he
 refuses to hear the Church also, let him be to you as a Gentile or a tax
 collector. <sup class="calibre31">18</sup>Amen, I tell you<a title="" href="part0000_split_124.html#_edn249" class="pcalibre pcalibre1" id="_ednref249"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[249]</span></span></span></a>
@@ -245,7 +245,7 @@ times?”</p>
 seven times, but seventy times seven! <sup class="calibre31">23</sup>Therefore, the Kingdom of
 Heaven is like a king who wanted to settle his accounts with his slaves. <sup class="calibre31">24</sup>When
 he began the settlement, someone was brought in who owed him ten thousand
-talents.<a title="" href="part0000_split_124.html#_edn253" class="pcalibre pcalibre1" id="_ednref253"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[253]</span></span></span></a>
+talents.<a title="" href="part0000_split_124.html#_edn253" class="pcalibre pcalibre1" id="_ednref253"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[253]</span></span></span></a>
 <sup class="calibre31">25</sup>But because the slave<a title="" href="part0000_split_124.html#_edn254" class="pcalibre pcalibre1" id="_ednref254"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[254]</span></span></span></a>
 could not pay, his lord gave orders that he be sold, with his wife, children,
 and all that he had, so that payment may be made. <sup class="calibre31">26</sup>At this, the slave
@@ -254,7 +254,7 @@ will repay you all!’ <sup class="calibre31">27</sup>The lord of that slave, mo
 released him, and forgave him the debt.</p>
 
 <p class="msonormal1"><sup class="calibre31">28</sup>However, that slave went out and found one of
-his fellow slaves who owed him one hundred denarii.<a title="" href="part0000_split_124.html#_edn255" class="pcalibre pcalibre1" id="_ednref255"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[255]</span></span></span></a>
+his fellow slaves who owed him one hundred denarii.<a title="" href="part0000_split_124.html#_edn255" class="pcalibre pcalibre1" id="_ednref255"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[255]</span></span></span></a>
 He grabbed him and took him by the throat, saying: ‘Pay me what you owe!’</p>
 
 <p class="msonormal1"><sup class="calibre31">29</sup>And so, his fellow slave fell down at his feet
@@ -274,7 +274,7 @@ trespasses from your hearts.”</p>
 <p class="sectiontopic">About marriage and divorce—Eunuchs for the sake of the
 Kingdom</p>
 
-<p class="style365ptloweredby1ptlinespacingexactly2445pt" id="toc_4">19</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_4">19</p>
 
 <p class="msonormal1">When Jesus had finished [speaking] these words, he departed
 from Galilee and arrived at the borders of Judea, beyond the Jordan. <sup class="calibre31">2</sup>Great
@@ -284,9 +284,9 @@ reason?”</p>
 
 <p class="msonormal1"><sup class="calibre31">4</sup>Jesus answered, “Have you not read that he who
 made<a title="" href="part0000_split_124.html#_edn257" class="pcalibre pcalibre1" id="_ednref257"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[257]</span></span></span></a>
-them from the beginning made them male and female,<a title="" href="part0000_split_124.html#_edn258" class="pcalibre pcalibre1" id="_ednref258"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[258]</span></span></span></a>
+them from the beginning made them male and female,<a title="" href="part0000_split_124.html#_edn258" class="pcalibre pcalibre1" id="_ednref258"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[258]</span></span></span></a>
 <sup class="calibre31">5</sup>and said, ‘For this reason, a man shall leave his father and mother
-and shall be attached to his wife; and the two shall become one flesh?’<a title="" href="part0000_split_124.html#_edn259" class="pcalibre pcalibre1" id="_ednref259"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[259]</span></span></span></a>
+and shall be attached to his wife; and the two shall become one flesh?’<a title="" href="part0000_split_124.html#_edn259" class="pcalibre pcalibre1" id="_ednref259"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[259]</span></span></span></a>
 <sup class="calibre31">6</sup>And so, they are no longer two, but one flesh! Therefore, what God
 has joined together, let no one tear apart.”</p>
 
@@ -324,7 +324,7 @@ these.” <sup class="calibre31">15</sup>He laid his hands on them, and departed
 <p class="msonormal1"><sup class="calibre31">16</sup>Behold, a man came to him and asked, “Good<a title="" href="part0000_split_124.html#_edn263" class="pcalibre pcalibre1" id="_ednref263"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[263]</span></span></span></a>
 teacher, what good thing shall I do in order to have eternal life?”</p>
 
-<p class="msonormal1"><sup class="calibre31">17</sup>Jesus said to him, “Why do you call me good?<a title="" href="part0000_split_124.html#_edn264" class="pcalibre pcalibre1" id="_ednref264"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[264]</span></span></span></a>
+<p class="msonormal1"><sup class="calibre31">17</sup>Jesus said to him, “Why do you call me good?<a title="" href="part0000_split_124.html#_edn264" class="pcalibre pcalibre1" id="_ednref264"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[264]</span></span></span></a>
 No one is good but one, that is, God. But if you want to enter into life, keep
 the commandments.”</p>
 
@@ -332,7 +332,7 @@ the commandments.”</p>
 
 <p class="msonormal1">Jesus replied, “‘You shall not murder.’ ‘You shall not
 commit adultery.’ ‘You shall not steal.’ ‘You shall not bear false witness.’ <sup class="calibre31">19</sup>‘Honor
-your father and mother;’<a title="" href="part0000_split_124.html#_edn265" class="pcalibre pcalibre1" id="_ednref265"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[265]</span></span></span></a>
+your father and mother;’<a title="" href="part0000_split_124.html#_edn265" class="pcalibre pcalibre1" id="_ednref265"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[265]</span></span></span></a>
 and, ‘You shall love your neighbor as yourself.’”<a title="" href="part0000_split_124.html#_edn266" class="pcalibre pcalibre1" id="_ednref266"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[266]</span></span></span></a></p>
 
 <p class="msonormal1"><sup class="calibre31">20</sup>The young man then said to him, “All these
@@ -367,18 +367,18 @@ and many who are last will be first!”</p>
 
 <p class="sectiontopic">Laborers in the vineyard</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_5">20</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_5">20</p>
 
 <p class="msonormal1">“The Kingdom of Heaven is like a man who was the master of a
 household and who went out early in the morning to hire laborers for his
-vineyard. <sup class="calibre31">2</sup>After agreeing with the laborers for a [salary of one] denarius<a title="" href="part0000_split_124.html#_edn270" class="pcalibre pcalibre1" id="_ednref270"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[270]</span></span></span></a>
+vineyard. <sup class="calibre31">2</sup>After agreeing with the laborers for a [salary of one] denarius<a title="" href="part0000_split_124.html#_edn270" class="pcalibre pcalibre1" id="_ednref270"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[270]</span></span></span></a>
 a day, he sent them into his vineyard. <sup class="calibre31">3</sup>[Later], he went out when it
-was about the third hour<a title="" href="part0000_split_124.html#_edn271" class="pcalibre pcalibre1" id="_ednref271"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[271]</span></span></span></a>
+was about the third hour<a title="" href="part0000_split_124.html#_edn271" class="pcalibre pcalibre1" id="_ednref271"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[271]</span></span></span></a>
 and saw other men standing idle in the marketplace. <sup class="calibre31">4</sup>He told them,
 ‘You too should go into the vineyard, and I will pay you whatever is right.’ And
 so, they went their way. <sup class="calibre31">5</sup>Again, he went out when it was about the
-sixth and the ninth hour,<a title="" href="part0000_split_124.html#_edn272" class="pcalibre pcalibre1" id="_ednref272"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[272]</span></span></span></a>
-and did the same thing. <sup class="calibre31">6</sup>About the eleventh hour,<a title="" href="part0000_split_124.html#_edn273" class="pcalibre pcalibre1" id="_ednref273"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[273]</span></span></span></a>
+sixth and the ninth hour,<a title="" href="part0000_split_124.html#_edn272" class="pcalibre pcalibre1" id="_ednref272"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[272]</span></span></span></a>
+and did the same thing. <sup class="calibre31">6</sup>About the eleventh hour,<a title="" href="part0000_split_124.html#_edn273" class="pcalibre pcalibre1" id="_ednref273"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[273]</span></span></span></a>
 he went out and still found others standing idle. He asked them, ‘Why do you
 stand here all day, doing nothing?’</p>
 
@@ -443,7 +443,7 @@ with the two brothers.</p>
 <p class="msonormal1"><sup class="calibre31">25</sup>However, Jesus called them together and said, “You
 know that the rulers of the nations lord it over them, and great ones make
 their authority felt. <sup class="calibre31">26</sup>But it shall not be so among you! Instead,
-whoever desires to become great among you shall be<a title="" href="part0000_split_124.html#_edn279" class="pcalibre pcalibre1" id="_ednref279"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[279]</span></span></span></a>
+whoever desires to become great among you shall be<a title="" href="part0000_split_124.html#_edn279" class="pcalibre pcalibre1" id="_ednref279"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[279]</span></span></span></a>
 your servant. <sup class="calibre31">27</sup>Whoever desires to be first<a title="" href="part0000_split_124.html#_edn280" class="pcalibre pcalibre1" id="_ednref280"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[280]</span></span></span></a>
 among you shall be your slave,<a title="" href="part0000_split_124.html#_edn281" class="pcalibre pcalibre1" id="_ednref281"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[281]</span></span></span></a>
 <sup class="calibre31">28</sup>even as the Son of Man came not to be served, but to serve, and to
@@ -471,7 +471,7 @@ him.</p>
 
 <p class="sectiontopic">The Lord’s entrance into Jerusalem</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_6">21</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_6">21</p>
 
 <p class="msonormal1">As they were approaching Jerusalem and came to Bethsphage,<a title="" href="part0000_split_124.html#_edn285" class="pcalibre pcalibre1" id="_ednref285"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[285]</span></span></span></a>
 to the Mount of Olives, Jesus sent two disciples [ahead of the group]. <sup class="calibre31">2</sup>He
@@ -511,7 +511,7 @@ multitude answered, “This is Jesus, the prophet from Nazareth of Galilee!”</
 and drove out all of those who did business there.<a title="" href="part0000_split_124.html#_edn291" class="pcalibre pcalibre1" id="_ednref291"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[291]</span></span></span></a>
 He overthrew the table of the money changers and the seats of those who sold
 doves. <sup class="calibre31">13</sup>He said to them, “It is written, ‘My house shall be called
-a house of prayer,’<a title="" href="part0000_split_124.html#_edn292" class="pcalibre pcalibre1" id="_ednref292"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[292]</span></span></span></a>
+a house of prayer,’<a title="" href="part0000_split_124.html#_edn292" class="pcalibre pcalibre1" id="_ednref292"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[292]</span></span></span></a>
 but you have made it a den of thieves!”<a title="" href="part0000_split_124.html#_edn293" class="pcalibre pcalibre1" id="_ednref293"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[293]</span></span></span></a></p>
 
 <p class="msonormal1"><sup class="calibre31">14</sup>The blind and the lame came to him in the
@@ -621,7 +621,7 @@ but they feared the crowds because the people considered him to be a prophet.</p
 
 <p class="sectiontopic">The parable of the wedding feast—The wedding garment</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_7">22</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_7">22</p>
 
 <p class="msonormal1">Jesus now addressed them with another parable, saying: <sup class="calibre31">2</sup>“The
 Kingdom of Heaven is like a king who planned a wedding feast for his son. <sup class="calibre31">3</sup>He
@@ -692,7 +692,7 @@ resurrection, people<a title="" href="part0000_split_124.html#_edn307" class="pc
 neither marry nor are given in marriage, but they are like the angels of God<a title="" href="part0000_split_124.html#_edn308" class="pcalibre pcalibre1" id="_ednref308"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[308]</span></span></span></a>
 in heaven. <sup class="calibre31">31</sup>However, concerning the resurrection of the dead, have you
 not read what was spoken to you by God, saying: <sup class="calibre31">32</sup>‘I am the God of
-Abraham, and the God of Isaac, and the God of Jacob?’<a title="" href="part0000_split_124.html#_edn309" class="pcalibre pcalibre1" id="_ednref309"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[309]</span></span></span></a>
+Abraham, and the God of Isaac, and the God of Jacob?’<a title="" href="part0000_split_124.html#_edn309" class="pcalibre pcalibre1" id="_ednref309"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[309]</span></span></span></a>
 God is not the God of the dead,<a title="" href="part0000_split_124.html#_edn310" class="pcalibre pcalibre1" id="_ednref310"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[310]</span></span></span></a>
 but of the living!”</p>
 
@@ -707,9 +707,9 @@ question in order to test him. <sup class="calibre31">36</sup>“Teacher, which 
 commandment in the law?”</p>
 
 <p class="msonormal1"><sup class="calibre31">37</sup>Jesus said to him, “‘You shall love the Lord
-your God with all your heart, with all your soul, and with all your mind.’<a title="" href="part0000_split_124.html#_edn311" class="pcalibre pcalibre1" id="_ednref311"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[311]</span></span></span></a>
+your God with all your heart, with all your soul, and with all your mind.’<a title="" href="part0000_split_124.html#_edn311" class="pcalibre pcalibre1" id="_ednref311"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[311]</span></span></span></a>
 <sup class="calibre31">38</sup>This is the first and great commandment. <sup class="calibre31">39</sup>The second is
-like it: ‘You shall love your neighbor as yourself.’<a title="" href="part0000_split_124.html#_edn312" class="pcalibre pcalibre1" id="_ednref312"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[312]</span></span></span></a>
+like it: ‘You shall love your neighbor as yourself.’<a title="" href="part0000_split_124.html#_edn312" class="pcalibre pcalibre1" id="_ednref312"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[312]</span></span></span></a>
 <sup class="calibre31">40</sup>The entire law and the prophets depend on these two commandments.”</p>
 
 <p class="sectiontopic">About Messiah, Son of David</p>
@@ -738,7 +738,7 @@ that day on, no one dared to ask him any more questions.</p>
 
 <p class="sectiontopic">Woe on the Scribes and Pharisees</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_8">23</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_8">23</p>
 
 <p class="msonormal1">Jesus then spoke to the crowds and to his disciples, <sup class="calibre31">2</sup>saying,
 “The scribes and the Pharisees have seated themselves<a title="" href="part0000_split_124.html#_edn317" class="pcalibre pcalibre1" id="_ednref317"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[317]</span></span></span></a>
@@ -747,8 +747,8 @@ observe and do, but do not imitate their works; for they preach and [yet] do
 not act accordingly. <sup class="calibre31">4</sup>Indeed, they bind heavy burdens that are dreadful
 to bear and put them on people’s shoulders; but they themselves will not lift a
 finger to help them. <sup class="calibre31">5</sup>Instead, they do all their works to be seen by
-men. They make their phylacteries<a title="" href="part0000_split_124.html#_edn318" class="pcalibre pcalibre1" id="_ednref318"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[318]</span></span></span></a>
-broad, they enlarge the fringes<a title="" href="part0000_split_124.html#_edn319" class="pcalibre pcalibre1" id="_ednref319"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[319]</span></span></span></a>
+men. They make their phylacteries<a title="" href="part0000_split_124.html#_edn318" class="pcalibre pcalibre1" id="_ednref318"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[318]</span></span></span></a>
+broad, they enlarge the fringes<a title="" href="part0000_split_124.html#_edn319" class="pcalibre pcalibre1" id="_ednref319"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[319]</span></span></span></a>
 of their garments, <sup class="calibre31">6</sup>and love the place of honor at feasts. They love
 the best seats in the synagogues, <sup class="calibre31">7</sup>the greetings in the marketplaces,
 and to be called ‘Rabbi, Rabbi’<a title="" href="part0000_split_124.html#_edn320" class="pcalibre pcalibre1" id="_ednref320"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[320]</span></span></span></a>
@@ -767,11 +767,11 @@ you will receive a greater condemnation.</p>
 
 <p class="msonormal1"><sup class="calibre31">14</sup>Woe to you, scribes and Pharisees, hypocrites!
 Because you shut the Kingdom of Heaven in the face of people and you yourselves
-do not enter! And those who would enter, you prevent from doing so.<a title="" href="part0000_split_124.html#_edn323" class="pcalibre pcalibre1" id="_ednref323"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[323]</span></span></span></a>
+do not enter! And those who would enter, you prevent from doing so.<a title="" href="part0000_split_124.html#_edn323" class="pcalibre pcalibre1" id="_ednref323"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[323]</span></span></span></a>
 <sup class="calibre31">15</sup>Woe to you, scribes and Pharisees, hypocrites! For you travel
 around by sea and land to make one convert; and when one is converted, you make
 him twice as much of an heir<a title="" href="part0000_split_124.html#_edn324" class="pcalibre pcalibre1" id="_ednref324"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[324]</span></span></span></a>
-of Gehenna<a title="" href="part0000_split_124.html#_edn325" class="pcalibre pcalibre1" id="_ednref325"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[325]</span></span></span></a>
+of Gehenna<a title="" href="part0000_split_124.html#_edn325" class="pcalibre pcalibre1" id="_ednref325"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[325]</span></span></span></a>
 as yourselves.</p>
 
 <p class="msonormal1"><sup class="calibre31">16</sup>Woe to you, you blind guides, who say, ‘If
@@ -787,7 +787,7 @@ in it. <sup class="calibre31">22</sup>Whoever swears by heaven swears by the thr
 the one who sits on it.</p>
 
 <p class="msonormal1"><sup class="calibre31">23</sup>Woe to you, scribes and Pharisees, hypocrites!
-For you tithe mint, dill, and cumin,<a title="" href="part0000_split_124.html#_edn327" class="pcalibre pcalibre1" id="_ednref327"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[327]</span></span></span></a>
+For you tithe mint, dill, and cumin,<a title="" href="part0000_split_124.html#_edn327" class="pcalibre pcalibre1" id="_ednref327"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[327]</span></span></span></a>
 but you have not fulfilled the truly significant matters of the law: justice,
 mercy, and faith. It is these you should have practiced, without neglecting the
 others. <sup class="calibre31">24</sup>You are blind guides who filter out a fly and yet swallow
@@ -795,7 +795,7 @@ a camel!</p>
 
 <p class="msonormal1"><sup class="calibre31">25</sup>Woe to you, scribes and Pharisees, hypocrites!
 For you clean the outside of the cup and the platter, but inside, they are full
-of greed and unrighteousness.<a title="" href="part0000_split_124.html#_edn328" class="pcalibre pcalibre1" id="_ednref328"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[328]</span></span></span></a>
+of greed and unrighteousness.<a title="" href="part0000_split_124.html#_edn328" class="pcalibre pcalibre1" id="_ednref328"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[328]</span></span></span></a>
 <sup class="calibre31">26</sup>You blind Pharisees, first clean the inside of the cup and platter,
 so that the outside may also become clean.</p>
 
@@ -812,7 +812,7 @@ not have partaken with them in the blood of the prophets.’ <sup class="calibre
 you testify to yourselves that you are children of those who killed the
 prophets! <sup class="calibre31">32</sup>Fill up, then, the measure [of sin] of your forefathers.
 <sup class="calibre31">33</sup>You serpents, offspring of vipers, how will you escape the
-judgment of Gehenna<a title="" href="part0000_split_124.html#_edn329" class="pcalibre pcalibre1" id="_ednref329"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[329]</span></span></span></a>?
+judgment of Gehenna<a title="" href="part0000_split_124.html#_edn329" class="pcalibre pcalibre1" id="_ednref329"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[329]</span></span></span></a>?
 <sup class="calibre31">34</sup>Therefore, behold, I send you prophets, wise men, and scribes.
 Some of them you will kill and crucify; others you will flog in your synagogues
 and persecute from city to city. <sup class="calibre31">35</sup>Thus all the righteous blood shed
@@ -828,12 +828,12 @@ and stones those who are sent to her! How often have I desired to gather your
 children, just as a hen gathers her brood under her wings; but you were not
 willing! <sup class="calibre31">38</sup>Behold, your house is left to you in a desolate state. <sup class="calibre31">39</sup>For
 I tell you, you will not see me from now on until [the day when] you are saying,
-‘Blessed is he who comes in the Name of the Lord!’”<a title="" href="part0000_split_124.html#_edn331" class="pcalibre pcalibre1" id="_ednref331"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[331]</span></span></span></a></p>
+‘Blessed is he who comes in the Name of the Lord!’”<a title="" href="part0000_split_124.html#_edn331" class="pcalibre pcalibre1" id="_ednref331"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[331]</span></span></span></a></p>
 
 <p class="sectiontopic">Questions about the Lord’s coming—Prophecies of
 calamities</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_9">24</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_9">24</p>
 
 <p class="msonormal1">Jesus went out from the temple and was going on his way. His
 disciples came to him and showed him the buildings of the temple. <sup class="calibre31">2</sup>But
@@ -864,7 +864,7 @@ the end will come.</p>
 <p class="sectiontopic">The abomination of desolation—The great tribulation</p>
 
 <p class="msonormal1"><sup class="calibre31">15</sup>Therefore, when you see the abomination of
-desolation<a title="" href="part0000_split_124.html#_edn333" class="pcalibre pcalibre1" id="_ednref333"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[333]</span></span></span></a>
+desolation<a title="" href="part0000_split_124.html#_edn333" class="pcalibre pcalibre1" id="_ednref333"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[333]</span></span></span></a>
 which was spoken about by the prophet Daniel standing in the holy place (let
 the reader understand), <sup class="calibre31">16</sup>let those who are in Judea flee to the
 mountains. <sup class="calibre31">17</sup>The one who is on the housetop should not [even] go
@@ -894,7 +894,7 @@ coming of the Son of Man will be.</p>
 is, there the eagles<a title="" href="part0000_split_124.html#_edn336" class="pcalibre pcalibre1" id="_ednref336"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[336]</span></span></span></a>
 will be gathered together. <sup class="calibre31">29</sup>But immediately after the tribulation
 of those days, the sun will be darkened, the moon will not give its light, the
-stars will fall from the sky, the powers of the heavens will be shaken;<a title="" href="part0000_split_124.html#_edn337" class="pcalibre pcalibre1" id="_ednref337"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[337]</span></span></span></a>
+stars will fall from the sky, the powers of the heavens will be shaken;<a title="" href="part0000_split_124.html#_edn337" class="pcalibre pcalibre1" id="_ednref337"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[337]</span></span></span></a>
 <sup class="calibre31">30</sup>and then the sign of the Son of Man will appear in the sky.<a title="" href="part0000_split_124.html#_edn338" class="pcalibre pcalibre1" id="_ednref338"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[338]</span></span></span></a>
 All the tribes of the earth will mourn, and they will see the Son of Man coming
 on the clouds of heaven<a title="" href="part0000_split_124.html#_edn339" class="pcalibre pcalibre1" id="_ednref339"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[339]</span></span></span></a>
@@ -910,11 +910,11 @@ tree—The days of Noah—Hour and day unknown</span></p>
 its branch has become tender and puts forth its leaves, you know that the
 summer is near. <sup class="calibre31">33</sup>Likewise, when you see all these things, know that
 the time is near, even at the doors. <sup class="calibre31">34</sup>Amen, I tell you that this
-generation<a title="" href="part0000_split_124.html#_edn341" class="pcalibre pcalibre1" id="_ednref341"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[341]</span></span></span></a>
+generation<a title="" href="part0000_split_124.html#_edn341" class="pcalibre pcalibre1" id="_ednref341"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[341]</span></span></span></a>
 will not pass away until all these things are accomplished. <sup class="calibre31">35</sup>Heaven
 and earth will pass away,<a title="" href="part0000_split_124.html#_edn342" class="pcalibre pcalibre1" id="_ednref342"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[342]</span></span></span></a>
 but my words will not pass away. <sup class="calibre31">36</sup>No one knows that day and hour,
-not even the angels of heaven,<a title="" href="part0000_split_124.html#_edn343" class="pcalibre pcalibre1" id="_ednref343"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[343]</span></span></span></a>
+not even the angels of heaven,<a title="" href="part0000_split_124.html#_edn343" class="pcalibre pcalibre1" id="_ednref343"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[343]</span></span></span></a>
 but only my Father.</p>
 
 <p class="msonormal1"><sup class="calibre31">37</sup>As in the days of Noah, so will it be at the
@@ -948,7 +948,7 @@ of teeth.”</span></p>
 
 <p class="sectiontopic">The parable of the ten wise and foolish virgins</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_10">25</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_10">25</p>
 
 <p class="msonormal1">“Then the Kingdom of Heaven will be like ten virgins who
 took their lamps and went out to meet the bridegroom. <sup class="calibre31">2</sup>Five of them
@@ -957,7 +957,7 @@ lamps but brought no oil along with them, <sup class="calibre31">4</sup>whereas 
 brought oil in their vessels along with their lamps. <sup class="calibre31">5</sup>Now since the
 bridegroom was late, they all became tired and fell asleep. <sup class="calibre31">6</sup>But at
 midnight there was a cry, ‘Behold! The bridegroom is coming! Come out to meet
-him!’ <sup class="calibre31">7</sup>Then all those virgins arose and trimmed their lamps.<a title="" href="part0000_split_124.html#_edn347" class="pcalibre pcalibre1" id="_ednref347"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[347]</span></span></span></a>
+him!’ <sup class="calibre31">7</sup>Then all those virgins arose and trimmed their lamps.<a title="" href="part0000_split_124.html#_edn347" class="pcalibre pcalibre1" id="_ednref347"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[347]</span></span></span></a>
 <sup class="calibre31">8</sup>The foolish virgins said to the wise ones, ‘Give us some of your
 oil because our lamps are going out.’ <sup class="calibre31">9</sup>But the wise virgins answered:
 ‘What if there is not enough for us and you?<a title="" href="part0000_split_124.html#_edn348" class="pcalibre pcalibre1" id="_ednref348"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[348]</span></span></span></a>
@@ -1054,7 +1054,7 @@ punishment, but the righteous into eternal life.”</p>
 
 <p class="sectiontopic">The passion announced again—The plot against Jesus</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_11">26</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_11">26</p>
 
 <p class="msonormal1">When Jesus had finished speaking, he said to his disciples, <sup class="calibre31">2</sup>“You
 know that in two days the Passover is coming, and the Son of Man will be
@@ -1131,7 +1131,7 @@ singing [the psalms], they went out to the Mount of Olives.</p>
 
 <p class="msonormal1"><sup class="calibre31">31</sup>Then Jesus said to them, “All of you will
 stumble because of me tonight, for it is written, ‘I will strike the shepherd,
-and the sheep of the flock will be scattered.’<a title="" href="part0000_split_124.html#_edn360" class="pcalibre pcalibre1" id="_ednref360"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[360]</span></span></span></a>
+and the sheep of the flock will be scattered.’<a title="" href="part0000_split_124.html#_edn360" class="pcalibre pcalibre1" id="_ednref360"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[360]</span></span></span></a>
 <sup class="calibre31">32</sup>But after I am raised up, I will go before you into Galilee.”</p>
 
 <p class="msonormal1"><sup class="calibre31">33</sup>But Peter replied, “Even if all [others] will
@@ -1256,7 +1256,7 @@ will deny me three times.” He went out and wept bitterly.</p>
 
 <p class="sectiontopic">The Lord before Pilate—Judas hangs himself</p>
 
-<p class="style35ptloweredby1ptlinespacingexactly2445pt" id="toc_12">27</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_12">27</p>
 
 <p class="msonormal1">In the morning, all the chief priests and the presbyters of
 the people took counsel against Jesus to put him to death; <sup class="calibre31">2</sup>they
@@ -1519,7 +1519,7 @@ make the tomb secure, sealing the stone and setting a watch.</p>
 
 <p class="sectiontopic">The Lord’s resurrection</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_13">28</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_13">28</p>
 
 <p class="msonormal1">After<a title="" href="part0000_split_124.html#_edn393" class="pcalibre pcalibre1" id="_ednref393"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[393]</span></span></span></a>
 the Sabbath, as it began to dawn on the first day of the week, Mary Magdalene
@@ -1584,7 +1584,7 @@ end of the age.” Amen!<a title="" href="part0000_split_124.html#_edn402" class
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection5">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_42"></div>
 </div>

--- a/text/part0000_split_029.html
+++ b/text/part0000_split_029.html
@@ -7,14 +7,14 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection5">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_43"><a class="pcalibre pcalibre1" id="_Toc425418820"></a><a class="pcalibre pcalibre1" id="_Toc425418672"></a><a class="pcalibre pcalibre1" id="_Toc425418524"></a><a class="pcalibre pcalibre1" id="_Toc290636398"><span id="3V4-53f1c2fa46e747eea0a124c9756c4a6f" class="calibre25">(ACCORDING TO) MARK</span>  <br class="calibre6"/>
 </a><span class="calibre62">(ΚΑΤΑ
 ΜΑΡΚΟΝ)</span></h1>
 
 <p class="sectiontopic">The ministry of John the Baptist—The Lord’s baptism</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">The beginning of the Good News of Jesus Christ, the Son of
 God<a title="" href="part0000_split_124.html#_edn403" class="pcalibre pcalibre1" id="_ednref403"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[403]</span></span></span></a>.
@@ -130,7 +130,7 @@ people came to him from everywhere.</p>
 
 <p class="sectiontopic">The healing of a paralytic</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">After some time, when Jesus returned to Capernaum, it was
 heard that he was in the house. <sup class="calibre31">2</sup>Immediately, many people gathered
@@ -210,7 +210,7 @@ Sabbath.”</p>
 
 <p class="sectiontopic">The healing of a man with a withered hand—Other healings</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">Again, Jesus entered into the synagogue, and there was a man
 who had a withered hand. <sup class="calibre31">2</sup>The Pharisees<a title="" href="part0000_split_124.html#_edn431" class="pcalibre pcalibre1" id="_ednref431"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[431]</span></span></span></a>
@@ -288,13 +288,13 @@ brother, and my sister, and mother.”</p>
 
 <p class="sectiontopic">The parable of the sower—About the use of parables</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">4</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_4">4</p>
 
 <p class="msonormal1">Again he began to teach by the seaside. A great crowd was
 gathered close to him, so that he got into a boat in the lake and sat down
 while the people were on the shore. <sup class="calibre31">2</sup>He taught them many things in
 parables, saying, <sup class="calibre31">3</sup>“Listen! A farmer went out to sow. <sup class="calibre31">4</sup>As
-he sowed, some seed fell on the road and the birds<a title="" href="part0000_split_124.html#_edn440" class="pcalibre pcalibre1" id="_ednref440"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[440]</span></span></span></a>
+he sowed, some seed fell on the road and the birds<a title="" href="part0000_split_124.html#_edn440" class="pcalibre pcalibre1" id="_ednref440"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[440]</span></span></span></a>
 came and devoured it. <sup class="calibre31">5</sup>Others fell on the rocky ground where it had
 little soil and it sprang up right away. Because the soil was shallow, <sup class="calibre31">6</sup>when
 the sun came, it was scorched; and since it had no root, it withered away. <sup class="calibre31">7</sup>Others
@@ -329,7 +329,7 @@ Some multiply thirty times, some sixty, and some a hundred times!”</p>
 <p class="sectiontopic">The example of the lamp—Nothing hidden </p>
 
 <p class="msonormal1"><sup class="calibre31">21</sup>Jesus said to them, “Is a lamp brought in to be
-placed under a basket<a title="" href="part0000_split_124.html#_edn443" class="pcalibre pcalibre1" id="_ednref443"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[443]</span></span></span></a>
+placed under a basket<a title="" href="part0000_split_124.html#_edn443" class="pcalibre pcalibre1" id="_ednref443"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[443]</span></span></span></a>
 or under a bed? Is it not placed on a stand? <sup class="calibre31">22</sup>For there is nothing
 hidden which shall not be revealed,<a title="" href="part0000_split_124.html#_edn444" class="pcalibre pcalibre1" id="_ednref444"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[444]</span></span></span></a>
 and nothing was made secret that should not come to light. <sup class="calibre31">23</sup>Anyone
@@ -383,7 +383,7 @@ another, “Who then is this, that even the wind and the sea obey him?”</p>
 <p class="sectiontopic">The healing of the demoniac—The demons (legion) sent in
 the pigs</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_5">5</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_5">5</p>
 
 <p class="msonormal1">They arrived on the other side of the sea, into the country
 of the Gergesenes. <sup class="calibre31">2</sup>As soon as Jesus came out of the boat, a man
@@ -487,7 +487,7 @@ and told them to give her something to eat.</p>
 
 <p class="sectiontopic">Rejected in Nazareth</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_6">6</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_6">6</p>
 
 <p class="msonormal1">Jesus<a title="" href="part0000_split_124.html#_edn452" class="pcalibre pcalibre1" id="_ednref452"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[452]</span></span></span></a>
 left that place and came into his own country, and his disciples followed him. <sup class="calibre31">2</sup>When
@@ -619,7 +619,7 @@ rowed, because the wind was against them. Now about the fourth watch of
 the night, he came to them, walking on the sea, and would have passed them by. <sup class="calibre31">49</sup>But
 when they saw him walking on the sea, they thought that it was a ghost and
 cried out. <sup class="calibre31">50</sup>They all saw him and were troubled, but immediately,
-Jesus spoke with them and said, “Rejoice! It is I!</span><a title="" href="part0000_split_124.html#_edn467" class="pcalibre pcalibre1" id="_ednref467"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre27"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre30">[467]</span></span></span></span></a><span class="calibre27"> Do not be afraid!” <sup class="calibre31">51</sup>He got into the
+Jesus spoke with them and said, “Rejoice! It is I!</span><a title="" href="part0000_split_124.html#_edn467" class="pcalibre pcalibre1" id="_ednref467"><span class="footnote-ref"><span class="calibre27"><span class="footnote-ref"><span class="calibre30">[467]</span></span></span></span></a><span class="calibre27"> Do not be afraid!” <sup class="calibre31">51</sup>He got into the
 boat with them and the wind ceased. They were utterly astonished beyond measure
 and marveled greatly <sup class="calibre31">52</sup>because they had not understood about the
 [miracle of the] loaves, but their hearts were hardened.</span></p>
@@ -635,7 +635,7 @@ and as many as touched him were made well.</p>
 
 <p class="sectiontopic">Traditions that nullify the word of God</p>
 
-<p class="style35ptloweredby1ptlinespacingexactly2445pt" id="toc_7">7</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_7">7</p>
 
 <p class="msonormal1">Then the Pharisees and some of the scribes came from
 Jerusalem and gathered to [see] Jesus.<a title="" href="part0000_split_124.html#_edn469" class="pcalibre pcalibre1" id="_ednref469"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[469]</span></span></span></a>
@@ -669,9 +669,9 @@ to human tradition<a title="" href="part0000_split_124.html#_edn476" class="pcal
 washing of pitchers and cups, and you do many other such things.” <sup class="calibre31">9</sup>He
 said to them, “How ingeniously do you reject the commandment of God in order to
 keep your tradition! <sup class="calibre31">10</sup>For Moses said, ‘Honor your father and your
-mother;’</span><a title="" href="part0000_split_124.html#_edn477" class="pcalibre pcalibre1" id="_ednref477"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre27"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre30">[477]</span></span></span></span></a><span class="calibre27"> and, ‘Whoever speaks evil of father or mother
-should be put to death.’</span><a title="" href="part0000_split_124.html#_edn478" class="pcalibre pcalibre1" id="_ednref478"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre27"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre30">[478]</span></span></span></span></a><span class="calibre27"> <sup class="calibre31">11</sup>But you say, ‘If a man tells his
-father or mother, “Whatever [support] you might have received from me is Corban</span><a title="" href="part0000_split_124.html#_edn479" class="pcalibre pcalibre1" id="_ednref479"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre27"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre30">[479]</span></span></span></span></a><span class="calibre27"> (that is, dedicated to God)”’ <sup class="calibre31">12</sup>then
+mother;’</span><a title="" href="part0000_split_124.html#_edn477" class="pcalibre pcalibre1" id="_ednref477"><span class="footnote-ref"><span class="calibre27"><span class="footnote-ref"><span class="calibre30">[477]</span></span></span></span></a><span class="calibre27"> and, ‘Whoever speaks evil of father or mother
+should be put to death.’</span><a title="" href="part0000_split_124.html#_edn478" class="pcalibre pcalibre1" id="_ednref478"><span class="footnote-ref"><span class="calibre27"><span class="footnote-ref"><span class="calibre30">[478]</span></span></span></span></a><span class="calibre27"> <sup class="calibre31">11</sup>But you say, ‘If a man tells his
+father or mother, “Whatever [support] you might have received from me is Corban</span><a title="" href="part0000_split_124.html#_edn479" class="pcalibre pcalibre1" id="_ednref479"><span class="footnote-ref"><span class="calibre27"><span class="footnote-ref"><span class="calibre30">[479]</span></span></span></span></a><span class="calibre27"> (that is, dedicated to God)”’ <sup class="calibre31">12</sup>then
 you no longer allow him to do anything for his father or mother. <sup class="calibre31">13</sup>Thus,
 you nullify the word of God by your tradition which you have handed down.<a title="" href="part0000_split_124.html#_edn480" class="pcalibre pcalibre1" id="_ednref480"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre30">[480]</span></span></span></a> And you do many [other]
 things like this.”</span></p>
@@ -687,7 +687,7 @@ crowd, his disciples asked him about the parable. <sup class="calibre31">18</sup
 “Are you also without understanding? Do you not yet perceive that whatever goes
 into someone from the outside cannot defile that person <sup class="calibre31">19</sup>because it
 does not go into his heart but into the stomach, and then into the sewer (thus
-he declared all foods to be clean)<a title="" href="part0000_split_124.html#_edn482" class="pcalibre pcalibre1" id="_ednref482"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[482]</span></span></span></a>?”
+he declared all foods to be clean)<a title="" href="part0000_split_124.html#_edn482" class="pcalibre pcalibre1" id="_ednref482"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[482]</span></span></span></a>?”
 <sup class="calibre31">20</sup>He said, “What comes out of a person is what defiles that person. <sup class="calibre31">21</sup>Indeed,
 it is from within, out of human hearts, that evil thoughts proceed: adultery, sexual
 immorality, murder, theft,<sup class="calibre31"> 22</sup>greed,<a title="" href="part0000_split_124.html#_edn483" class="pcalibre pcalibre1" id="_ednref483"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[483]</span></span></span></a>
@@ -735,7 +735,7 @@ deaf hear, and the mute speak!”</p>
 
 <p class="sectiontopic">The feeding of the four thousand</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_8">8</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_8">8</p>
 
 <p class="msonormal1">In those days, another large crowd was [assembled] there and
 the people had nothing to eat. Jesus called his disciples to himself and told
@@ -849,7 +849,7 @@ with the holy angels.”</p>
 
 <p class="sectiontopic">The Lord’s transfiguration</p>
 
-<p class="style365ptloweredby1ptlinespacingexactly2445pt" id="toc_9">9</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_9">9</p>
 
 <p class="msonormal1">Jesus<a title="" href="part0000_split_124.html#_edn498" class="pcalibre pcalibre1" id="_ednref498"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[498]</span></span></span></a>
 said to them, “Amen, I tell you that there are some standing here who will not
@@ -981,19 +981,19 @@ be thrown into the sea with a millstone hung around the neck.”</p>
 
 <p class="msonormal1"><sup class="calibre31">43</sup>“If your hand causes you to stumble, cut it
 off! It is better for you to enter into life maimed, rather than have your two
-hands and go into Gehenna,<a title="" href="part0000_split_124.html#_edn506" class="pcalibre pcalibre1" id="_ednref506"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[506]</span></span></span></a>
+hands and go into Gehenna,<a title="" href="part0000_split_124.html#_edn506" class="pcalibre pcalibre1" id="_ednref506"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[506]</span></span></span></a>
 the unquenchable fire <sup class="calibre31">44</sup>&lt;‘where their worm does not die, and the
 fire is not quenched.’&gt;<a title="" href="part0000_split_124.html#_edn507" class="pcalibre pcalibre1" id="_ednref507"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[507]</span></span></span></a>
 <sup class="calibre31">45</sup>If your foot causes you to stumble, cut it off! It is better for
 you to enter into life lame, rather than having your two feet to be cast into
-Gehenna,<a title="" href="part0000_split_124.html#_edn508" class="pcalibre pcalibre1" id="_ednref508"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[508]</span></span></span></a>
+Gehenna,<a title="" href="part0000_split_124.html#_edn508" class="pcalibre pcalibre1" id="_ednref508"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[508]</span></span></span></a>
 the fire that will never be quenched, <sup class="calibre31">46</sup>&lt;‘where their worm does
 not die, and the fire is not quenched.’&gt;<a title="" href="part0000_split_124.html#_edn509" class="pcalibre pcalibre1" id="_ednref509"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[509]</span></span></span></a>
 <sup class="calibre31">47</sup>If your eye causes you to stumble, pluck it out! It is better for
 you to enter into the Kingdom of God with one eye, rather than with two eyes to
-go into the Gehenna<a title="" href="part0000_split_124.html#_edn510" class="pcalibre pcalibre1" id="_ednref510"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[510]</span></span></span></a>
+go into the Gehenna<a title="" href="part0000_split_124.html#_edn510" class="pcalibre pcalibre1" id="_ednref510"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[510]</span></span></span></a>
 of fire, <sup class="calibre31">48</sup>&lt;‘where their worm does not die, and the fire is not
-quenched.’&gt;<a title="" href="part0000_split_124.html#_edn511" class="pcalibre pcalibre1" id="_ednref511"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[511]</span></span></span></a>
+quenched.’&gt;<a title="" href="part0000_split_124.html#_edn511" class="pcalibre pcalibre1" id="_ednref511"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[511]</span></span></span></a>
 </p>
 
 <p class="sectiontopic">About salt</p>
@@ -1005,7 +1005,7 @@ will you season it? Have salt in yourselves, and be at peace with one another.�
 
 <p class="sectiontopic">About marriage and divorce</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_10">10</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_10">10</p>
 
 <p class="msonormal1">Jesus then left that place and arrived at the borders of
 Judea, by the other side of the Jordan. Again, crowds were gathering around
@@ -1020,9 +1020,9 @@ divorce to be written, and to divorce her.”<a title="" href="part0000_split_12
 
 <p class="msonormal1"><sup class="calibre31">5</sup>But Jesus answered and said to them, “It was
 because of your hardness of heart that Moses wrote this law for you. <sup class="calibre31">6</sup>But
-from the beginning of creation, God made them male and female.<a title="" href="part0000_split_124.html#_edn515" class="pcalibre pcalibre1" id="_ednref515"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[515]</span></span></span></a>
+from the beginning of creation, God made them male and female.<a title="" href="part0000_split_124.html#_edn515" class="pcalibre pcalibre1" id="_ednref515"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[515]</span></span></span></a>
 <sup class="calibre31">7</sup>For this reason, a man will leave his father and mother, and will
-join to his wife, <sup class="calibre31">8</sup>and the two will become one flesh.<a title="" href="part0000_split_124.html#_edn516" class="pcalibre pcalibre1" id="_ednref516"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[516]</span></span></span></a>
+join to his wife, <sup class="calibre31">8</sup>and the two will become one flesh.<a title="" href="part0000_split_124.html#_edn516" class="pcalibre pcalibre1" id="_ednref516"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[516]</span></span></span></a>
 Thus, they are no longer two, but one flesh. <sup class="calibre31">9</sup>What therefore God has
 joined together, let no one tear apart!”</p>
 
@@ -1164,7 +1164,7 @@ along the way.</p>
 
 <p class="sectiontopic">The Entrance into Jerusalem</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_11">11</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_11">11</p>
 
 <p class="msonormal1">As they were approaching Jerusalem, at Bethsphage<a title="" href="part0000_split_124.html#_edn525" class="pcalibre pcalibre1" id="_ednref525"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[525]</span></span></span></a>
 and Bethany near the Mount of Olives, Jesus<a title="" href="part0000_split_124.html#_edn526" class="pcalibre pcalibre1" id="_ednref526"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[526]</span></span></span></a>
@@ -1215,7 +1215,7 @@ entered into the temple. He began to drive out those who did business<a title=""
 in the temple and he overthrew the tables of the money changers, as well as the
 seats of those who sold doves. <sup class="calibre31">16</sup>He would not allow anyone to carry
 a container through the temple. <sup class="calibre31">17</sup>He taught them, saying, “Is it not
-written, ‘My house will be called a house of prayer for all the nations?’<a title="" href="part0000_split_124.html#_edn532" class="pcalibre pcalibre1" id="_ednref532"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[532]</span></span></span></a>
+written, ‘My house will be called a house of prayer for all the nations?’<a title="" href="part0000_split_124.html#_edn532" class="pcalibre pcalibre1" id="_ednref532"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[532]</span></span></span></a>
 But you have made it a ‘den of thieves!’”<a title="" href="part0000_split_124.html#_edn533" class="pcalibre pcalibre1" id="_ednref533"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[533]</span></span></span></a></p>
 
 <p class="msonormal1"><sup class="calibre31">18</sup>When the chief priests and scribes and
@@ -1260,7 +1260,7 @@ by what authority I do these things.”</p>
 
 <p class="sectiontopic">The parable of the tenant farmers of the vineyard</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_12">12</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_12">12</p>
 
 <p class="msonormal1">He began to speak to them in parables. “A man planted a
 vineyard, put a hedge around it, dug a pit for the winepress, and built a tower.
@@ -1332,7 +1332,7 @@ when people {will} rise from the dead, they do not marry nor are given in
 marriage; instead, they are like angels in heaven. <sup class="calibre31">26</sup>But regarding the
 fact that the dead are raised, have you not read in the book of Moses (in the
 passage about the bush), how God spoke to him, saying: ‘I am the God of Abraham,
-the God of Isaac, and the God of Jacob?’<a title="" href="part0000_split_124.html#_edn545" class="pcalibre pcalibre1" id="_ednref545"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[545]</span></span></span></a>
+the God of Isaac, and the God of Jacob?’<a title="" href="part0000_split_124.html#_edn545" class="pcalibre pcalibre1" id="_ednref545"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[545]</span></span></span></a>
 <sup class="calibre31">27</sup>He is not the God of the dead, but of the living! This is why you
 are greatly misled.”<a title="" href="part0000_split_124.html#_edn546" class="pcalibre pcalibre1" id="_ednref546"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[546]</span></span></span></a></p>
 
@@ -1345,9 +1345,9 @@ commandment is the greatest of all?”</p>
 <p class="msonormal1"><sup class="calibre31">29</sup>Jesus answered him, “The greatest is, ‘Hear,
 Israel, the Lord our God, the Lord is one: <sup class="calibre31">30</sup>you shall love the Lord
 your God with all your heart, and with all your soul, and with all your mind,
-and with all your strength.’<a title="" href="part0000_split_124.html#_edn547" class="pcalibre pcalibre1" id="_ednref547"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[547]</span></span></span></a>
+and with all your strength.’<a title="" href="part0000_split_124.html#_edn547" class="pcalibre pcalibre1" id="_ednref547"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[547]</span></span></span></a>
 This is the first commandment. <sup class="calibre31">31</sup>And the second is likewise,<a title="" href="part0000_split_124.html#_edn548" class="pcalibre pcalibre1" id="_ednref548"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[548]</span></span></span></a>
-‘You shall love your neighbor as yourself.’<a title="" href="part0000_split_124.html#_edn549" class="pcalibre pcalibre1" id="_ednref549"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[549]</span></span></span></a>
+‘You shall love your neighbor as yourself.’<a title="" href="part0000_split_124.html#_edn549" class="pcalibre pcalibre1" id="_ednref549"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[549]</span></span></span></a>
 There is no other commandment greater than these.”</p>
 
 <p class="msonormal1"><sup class="calibre31">32</sup>The scribe said to him, “It is well, teacher,
@@ -1397,7 +1397,7 @@ out of her poverty, gave all that she had to live on.”</p>
 <p class="sectiontopic">The destruction of the Temple is foretold—The signs of
 the end</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_13">13</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_13">13</p>
 
 <p class="msonormal1">As Jesus went out of the temple, one of his disciples said
 to him, “Teacher, look! What [amazing] stones and buildings!”</p>
@@ -1413,7 +1413,7 @@ about to be fulfilled?”</p>
 
 <p class="msonormal1"><sup class="calibre31">5</sup>Then Jesus, answering them, began to say, “Be
 careful that no one leads you astray! <sup class="calibre31">6</sup>For many will come in my Name,
-saying: ‘I am he!<a title="" href="part0000_split_124.html#_edn556" class="pcalibre pcalibre1" id="_ednref556"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[556]</span></span></span></a>’
+saying: ‘I am he!<a title="" href="part0000_split_124.html#_edn556" class="pcalibre pcalibre1" id="_ednref556"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[556]</span></span></span></a>’
 and they will lead many astray.</p>
 
 <p class="msonormal1"><sup class="calibre31">7</sup>But when you hear of wars and rumors of wars, do
@@ -1438,7 +1438,7 @@ the Holy Spirit.</p>
 death, and a father his [own] child. Children will rise up against parents and
 cause them to be put to death. <sup class="calibre31">13</sup>You will be hated by all for my Name’s
 sake, but the one who endures to the end will be saved. <sup class="calibre31">14</sup>But when
-you see the abomination of desolation<a title="" href="part0000_split_124.html#_edn558" class="pcalibre pcalibre1" id="_ednref558"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[558]</span></span></span></a>
+you see the abomination of desolation<a title="" href="part0000_split_124.html#_edn558" class="pcalibre pcalibre1" id="_ednref558"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[558]</span></span></span></a>
 spoken of by Daniel the prophet<a title="" href="part0000_split_124.html#_edn559" class="pcalibre pcalibre1" id="_ednref559"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[559]</span></span></span></a>
 standing where it should not stand (let the reader understand), then those who
 are in Judea should flee to the mountains. <sup class="calibre31">15</sup>Then whoever is on the
@@ -1458,7 +1458,7 @@ will show signs and wonders in order to lead astray, if possible, even the elect
 <p class="msonormal1">Behold, I have told you all things beforehand. <sup class="calibre31">24</sup>But
 in those days, after that tribulation, the sun will be darkened, the moon will
 not give its light, <sup class="calibre31">25</sup>the stars will be falling from the sky, and
-the powers that are in the heavens will be shaken.<a title="" href="part0000_split_124.html#_edn560" class="pcalibre pcalibre1" id="_ednref560"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[560]</span></span></span></a>
+the powers that are in the heavens will be shaken.<a title="" href="part0000_split_124.html#_edn560" class="pcalibre pcalibre1" id="_ednref560"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[560]</span></span></span></a>
 <sup class="calibre31">26</sup>Then people will see the Son of Man coming in the clouds with
 great power and glory. <sup class="calibre31">27</sup>After that, he will send out his angels and
 [they] will gather his elect from the four winds, from the ends of the earth to
@@ -1487,7 +1487,7 @@ sleeping. <sup class="calibre31">37</sup>The things I tell you, I [also] tell ev
 <p class="sectiontopic">The plot against Jesus—The anointing of the Lord at
 Bethany</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_14">14</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_14">14</p>
 
 <p class="msonormal1">It was now two days before the feast of the Passover and of
 the unleavened bread. The chief priests and the scribes were seeking a way to
@@ -1559,7 +1559,7 @@ they went out to the Mount of Olives.</p>
 <p class="msonormal1"><sup class="calibre31">27</sup>Jesus said to them, “All of you will be made to
 stumble <a class="pcalibre pcalibre1" id="OLE_LINK6"></a><a class="pcalibre pcalibre1" id="OLE_LINK5">because of me tonight</a>,<a title="" href="part0000_split_124.html#_edn568" class="pcalibre pcalibre1" id="_ednref568"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[568]</span></span></span></a>
 for it is written, ‘I will strike the shepherd, and the sheep will be
-scattered.’<a title="" href="part0000_split_124.html#_edn569" class="pcalibre pcalibre1" id="_ednref569"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[569]</span></span></span></a>
+scattered.’<a title="" href="part0000_split_124.html#_edn569" class="pcalibre pcalibre1" id="_ednref569"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[569]</span></span></span></a>
 <sup class="calibre31">28</sup>However, after I am raised up, I will go before you into Galilee.”</p>
 
 <p class="msonormal1"><sup class="calibre31">29</sup>But Peter said to him, “Even if all fall away,
@@ -1677,7 +1677,7 @@ you will deny me three times.” When he thought about that,<a title="" href="pa
 
 <p class="sectiontopic">Before Pilate—The Lord is condemned to be crucified</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_15">15</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_15">15</p>
 
 <p class="msonormal1">As soon as it was the morning, the chief priests, the
 presbyters, the scribes, and the whole council held a consultation. Having bound
@@ -1799,7 +1799,7 @@ had been laid.</p>
 
 <p class="sectiontopic">The Lord’s resurrection</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_16">16</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_16">16</p>
 
 <p class="msonormal1">When the Sabbath was past, Mary Magdalene, Mary the mother
 of James, and Salome, bought spices in order to come and anoint him. <sup class="calibre31">2</sup>Very
@@ -1898,7 +1898,7 @@ Amen.&gt;&gt;</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection6">
+<div class="section">
 
 <p class="msonormal15"> </p>
 

--- a/text/part0000_split_030.html
+++ b/text/part0000_split_030.html
@@ -7,13 +7,13 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection6">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_45"><a class="pcalibre pcalibre1" id="_Toc425418821"></a><a class="pcalibre pcalibre1" id="_Toc425418674"></a><a class="pcalibre pcalibre1" id="_Toc425418526"></a><a class="pcalibre pcalibre1" id="_Toc290636399"><span id="5RC-53f1c2fa46e747eea0a124c9756c4a6f" class="calibre25">(ACCORDING TO) LUKE</span>  <br class="calibre6"/>
 </a><span class="calibre60">(</span><span class="calibre60">ΚΑΤΑ</span><span class="calibre60"> </span><span class="calibre60">ΛΟΥΚΑΝ</span><span class="calibre60">)</span></h1>
 
 <p class="sectiontopic">Luke’s motivations and methods</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">Many<a title="" href="part0000_split_124.html#_edn614" class="pcalibre pcalibre1" id="_ednref614"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[614]</span></span></span></a>
 have undertaken to set in order a narrative concerning those matters which have
@@ -254,7 +254,7 @@ Israel.</p>
 
 <p class="sectiontopic">The Nativity of our Lord</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">In those days, Caesar Augustus issued a decree that a census
 should be taken of the entire [Roman] world. <sup class="calibre31">2</sup>This was the first
@@ -390,7 +390,7 @@ Jesus increased in wisdom and stature, as well as in favor with God and men.</p>
 
 <p class="sectiontopic">The ministry of John the Baptist</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">Now in the fifteenth year of the reign of Tiberius Caesar,
 Pontius Pilate being governor of Judea, Herod being tetrarch of Galilee, his
@@ -495,7 +495,7 @@ Adam, the son of God.</p>
 
 <p class="sectiontopic">The temptation in the desert</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">4</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_4">4</p>
 
 <p class="msonormal1">Full of the Holy Spirit, Jesus returned from the Jordan, and
 was led by the Spirit into the wilderness. <sup class="calibre31">2</sup>For forty days, he was
@@ -635,7 +635,7 @@ preaching in the synagogues of Galilee.<a title="" href="part0000_split_124.html
 
 <p class="sectiontopic">The calling of Simon (Peter), James and John</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_5">5</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_5">5</p>
 
 <p class="msonormal1">Now it happened, while the multitude pressed on him and
 heard the word of God, that he was standing by the lake of Gennesaret. <sup class="calibre31">2</sup>He
@@ -743,7 +743,7 @@ who has drunk old wine immediately desires new, for he says, ‘The old is bette
 
 <p class="sectiontopic">About the Sabbath</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_6">6</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_6">6</p>
 
 <p class="msonormal1">Now it happened on the second Sabbath after the first<a title="" href="part0000_split_124.html#_edn702" class="pcalibre pcalibre1" id="_ednref702"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[702]</span></span></span></a>
 [that] Jesus<a title="" href="part0000_split_124.html#_edn703" class="pcalibre pcalibre1" id="_ednref703"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[703]</span></span></span></a>
@@ -878,7 +878,7 @@ of the Most High, for he is kind [even] to the ungrateful and evil.</p>
 <p class="poetry1cxspmiddle">and you will be set free.</p>
 
 <p class="msonormal1"><sup class="calibre31">38</sup>Give, and it will be given to you: a good
-measure, pressed down, shaken together, and overflowing will be given to you.<a title="" href="part0000_split_124.html#_edn714" class="pcalibre pcalibre1" id="_ednref714"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[714]</span></span></span></a>
+measure, pressed down, shaken together, and overflowing will be given to you.<a title="" href="part0000_split_124.html#_edn714" class="pcalibre pcalibre1" id="_ednref714"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[714]</span></span></span></a>
 For with the same measure [that] you measure, it will be measured back to you.”</p>
 
 <p class="sectiontopic">The beam and the speck—Judging others—The tree and its
@@ -918,7 +918,7 @@ and at once it fell down; and the ruin of that house was great.”</p>
 
 <p class="sectiontopic">The healing of the Centurion’s servant</p>
 
-<p class="style35ptloweredby1ptlinespacingexactly2445pt" id="toc_7">7</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_7">7</p>
 
 <p class="msonormal1">Now when Jesus had finished speaking all that he wanted the
 people to hear, he entered into Capernaum. <sup class="calibre31">2</sup>There was the slave of a
@@ -1051,7 +1051,7 @@ saved you. Go in peace.”</p>
 
 <p class="sectiontopic">The women disciples of the Lord</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_8">8</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_8">8</p>
 
 <p class="msonormal1">Soon afterwards, Jesus<a title="" href="part0000_split_125.html#_edn730" class="pcalibre pcalibre1" id="_ednref730"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[730]</span></span></span></a>
 went through cities and villages, preaching and bringing the Good News of the
@@ -1080,7 +1080,7 @@ parable mean?”</p>
 
 <p class="msonormal1"><sup class="calibre31">10</sup>Jesus replied, “To you it is given to know the
 mysteries of the Kingdom of God, but to the rest, [it is given] in parables, so
-that ‘seeing they may not see, and hearing they may not understand.’<a title="" href="part0000_split_125.html#_edn733" class="pcalibre pcalibre1" id="_ednref733"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[733]</span></span></span></a>
+that ‘seeing they may not see, and hearing they may not understand.’<a title="" href="part0000_split_125.html#_edn733" class="pcalibre pcalibre1" id="_ednref733"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[733]</span></span></span></a>
 <sup class="calibre31">11</sup>Now this is what the parable means: The seed is the word of God. <sup class="calibre31">12</sup>Those
 along the wayside are those who have heard. Then the devil comes and takes away
 the word from their heart, so that they may not believe and be saved. <sup class="calibre31">13</sup>Those
@@ -1216,7 +1216,7 @@ tell no one what had been done.</p>
 
 <p class="sectiontopic">The commission of the Twelve apostles</p>
 
-<p class="style365ptloweredby1ptlinespacingexactly2445pt" id="toc_9">9</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_9">9</p>
 
 <p class="msonormal1">Calling his twelve disciples<a title="" href="part0000_split_125.html#_edn753" class="pcalibre pcalibre1" id="_ednref753"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[753]</span></span></span></a>
 together, Jesus gave them power and authority over all demons, and [power] to
@@ -1292,7 +1292,7 @@ killed, and the third day be raised up.”</p>
 <p class="sectiontopic">Requirements for discipleship</p>
 
 <p class="msonormal1"><sup class="calibre31">23</sup>Jesus said to all, “Anyone who desires to come
-after me must deny himself, take up his cross daily,<a title="" href="part0000_split_125.html#_edn759" class="pcalibre pcalibre1" id="_ednref759"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[759]</span></span></span></a>
+after me must deny himself, take up his cross daily,<a title="" href="part0000_split_125.html#_edn759" class="pcalibre pcalibre1" id="_ednref759"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[759]</span></span></span></a>
 and follow me. <sup class="calibre31">24</sup>For whoever desires to save his life will lose it,
 but whoever will lose his life for my sake will save it. <sup class="calibre31">25</sup>Indeed
 what profit is there if someone gains the whole world but loses or surrenders<a title="" href="part0000_split_125.html#_edn760" class="pcalibre pcalibre1" id="_ednref760"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[760]</span></span></span></a>
@@ -1412,7 +1412,7 @@ hand to the plow and looks back is fit for the Kingdom of God.”</p>
 
 <p class="sectiontopic">The seventy apostles</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_10">10</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_10">10</p>
 
 <p class="msonormal1">After these things, the Lord also appointed seventy<a title="" href="part0000_split_125.html#_edn771" class="pcalibre pcalibre1" id="_ednref771"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[771]</span></span></span></a>
 others and sent them two by two ahead of him<a title="" href="part0000_split_125.html#_edn772" class="pcalibre pcalibre1" id="_ednref772"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[772]</span></span></span></a>
@@ -1440,7 +1440,7 @@ tolerable in that day for Sodom than for such a city.</span></p>
 For if the deeds of power which were done in you had been done in Tyre and
 Sidon, they would have repented long ago, sitting in sackcloth and ashes. <sup class="calibre31">14</sup>But
 in the judgment, it will be more tolerable for Tyre and Sidon than for you. <sup class="calibre31">15</sup>And
-you, Capernaum, who are exalted to heaven, you will be brought down to hades<a title="" href="part0000_split_125.html#_edn774" class="pcalibre pcalibre1" id="_ednref774"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[774]</span></span></span></a>!
+you, Capernaum, who are exalted to heaven, you will be brought down to hades<a title="" href="part0000_split_125.html#_edn774" class="pcalibre pcalibre1" id="_ednref774"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[774]</span></span></span></a>!
 <sup class="calibre31">16</sup>Whoever listens to you listens to me, and whoever rejects you
 rejects me. Whoever rejects me rejects the one who sent me.”</p>
 

--- a/text/part0000_split_031.html
+++ b/text/part0000_split_031.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection6">
+<div class="section">
 <p class="msonormal1">Then Jesus said to him, “Go and do likewise.”</p>
 
 <p class="sectiontopic">Martha and Mary</p>
@@ -25,7 +25,7 @@ and Mary has chosen the good part, which will not be taken away from her.”</p>
 
 <p class="sectiontopic"> ‘The Lord’s Prayer’<a title="" href="part0000_split_125.html#_edn785" class="pcalibre pcalibre1" id="_ednref785"><span class="msoendnotereference"><span class="msoendnotereference"><b class="calibre7"><span class="calibre28">[785]</span></b></span></span></a></p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">11</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">11</p>
 
 <p class="msonormal1">One day, when Jesus<a title="" href="part0000_split_125.html#_edn786" class="pcalibre pcalibre1" id="_ednref786"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[786]</span></span></span></a>
 had finished praying in a certain place, one of his disciples said to him, “Lord,
@@ -191,7 +191,7 @@ order to accuse him.</p>
 
 <p class="sectiontopic">Warning about the Pharisees—Nothing is hidden</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">12</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">12</p>
 
 <p class="msonormal1">Meanwhile, a crowd of many thousands had gathered, to the
 point that they trampled on each other. Jesus began to speak, first of all to
@@ -207,10 +207,10 @@ housetops.</p>
 those who kill the body and after that can do no more. <sup class="calibre31">5</sup>But I will
 warn<a title="" href="part0000_split_125.html#_edn805" class="pcalibre pcalibre1" id="_ednref805"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[805]</span></span></span></a>
 you whom you should fear: fear the one who after he has killed, [also] has power
-to cast into Gehenna.<a title="" href="part0000_split_125.html#_edn806" class="pcalibre pcalibre1" id="_ednref806"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[806]</span></span></span></a>
+to cast into Gehenna.<a title="" href="part0000_split_125.html#_edn806" class="pcalibre pcalibre1" id="_ednref806"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[806]</span></span></span></a>
 Yes, I tell you, fear him!</p>
 
-<p class="msonormal1"><sup class="calibre31">6</sup>Are not five sparrows sold for two small coins<a title="" href="part0000_split_125.html#_edn807" class="pcalibre pcalibre1" id="_ednref807"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[807]</span></span></span></a>?
+<p class="msonormal1"><sup class="calibre31">6</sup>Are not five sparrows sold for two small coins<a title="" href="part0000_split_125.html#_edn807" class="pcalibre pcalibre1" id="_ednref807"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[807]</span></span></span></a>?
 Yet not one of them is forgotten by God. <sup class="calibre31">7</sup>Indeed, the very hairs of
 your head are all numbered. Therefore, do not be afraid! You are of more value
 than many sparrows.</p>
@@ -324,7 +324,7 @@ division. <sup class="calibre31">52</sup>For from now on, there will be five in 
 three against two, and two against three. <sup class="calibre31">53</sup>They will be divided,
 father against son, son against father; mother against daughter, and daughter
 against her mother; mother-in-law against her daughter-in-law, and
-daughter-in-law against her mother-in-law.”<a title="" href="part0000_split_125.html#_edn819" class="pcalibre pcalibre1" id="_ednref819"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[819]</span></span></span></a></p>
+daughter-in-law against her mother-in-law.”<a title="" href="part0000_split_125.html#_edn819" class="pcalibre pcalibre1" id="_ednref819"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[819]</span></span></span></a></p>
 
 <p class="sectiontopic">Interpreting the signs of the time—Making peace with
 opponents</p>
@@ -342,12 +342,12 @@ magistrate, as you are on the way, do your utmost to be released from him, for
 fear that perhaps he will drag you to the judge, and the judge might deliver
 you to the officer, and the officer might throw you into prison. <sup class="calibre31">59</sup>I
 tell you, you will by no means get out of there, until you have paid the very
-last penny.<a title="" href="part0000_split_125.html#_edn820" class="pcalibre pcalibre1" id="_ednref820"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[820]</span></span></span></a>
+last penny.<a title="" href="part0000_split_125.html#_edn820" class="pcalibre pcalibre1" id="_ednref820"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[820]</span></span></span></a>
 ”</p>
 
 <p class="sectiontopic">Call to repentance</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">13</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">13</p>
 
 <p class="msonormal1">At that time, some [Jews] were present who told Jesus about
 the Galileans whose blood Pilate had mixed with their sacrifices. <sup class="calibre31">2</sup>Jesus
@@ -403,7 +403,7 @@ in its branches.”</p>
 
 <p class="msonormal1"><sup class="calibre31">20</sup>Again he said, “To what shall I compare the
 Kingdom of God? <sup class="calibre31">21</sup>It is like yeast, which a woman took and hid in
-three measures<a title="" href="part0000_split_125.html#_edn823" class="pcalibre pcalibre1" id="_ednref823"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[823]</span></span></span></a>
+three measures<a title="" href="part0000_split_125.html#_edn823" class="pcalibre pcalibre1" id="_ednref823"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[823]</span></span></span></a>
 of flour, until it was all leavened.”</p>
 
 <p class="msonormal1"><sup class="calibre31">22</sup>Jesus was on his way through cities and
@@ -447,7 +447,7 @@ is he who comes in the Name of the Lord!’”<a title="" href="part0000_split_1
 
 <p class="sectiontopic">The healing of a man with dropsy on the Sabbath day</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">14</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_4">14</p>
 
 <p class="msonormal1">Now it happened that Jesus went into the house of one of the
 rulers of the Pharisees on a Sabbath to eat bread, and they were watching him
@@ -459,7 +459,7 @@ Sabbath?”</p>
 <p class="msonormal1"><sup class="calibre31">4</sup>But they remained silent.</p>
 
 <p class="msonormal1">So taking hold of the man, Jesus healed him and sent him
-away. <sup class="calibre31">5</sup>He answered them, “Which of you, if your son<a title="" href="part0000_split_125.html#_edn832" class="pcalibre pcalibre1" id="_ednref832"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[832]</span></span></span></a>
+away. <sup class="calibre31">5</sup>He answered them, “Which of you, if your son<a title="" href="part0000_split_125.html#_edn832" class="pcalibre pcalibre1" id="_ednref832"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[832]</span></span></span></a>
 or ox falls into a well on a Sabbath day, would not immediately pull it out?”</p>
 
 <p class="msonormal1"><sup class="calibre31">6</sup>And they could not answer him regarding these
@@ -524,7 +524,7 @@ taste of my supper.’”</p>
 
 <p class="msonormal1"><sup class="calibre31">25</sup>Great crowds were now traveling with him. He
 turned and said to them, <sup class="calibre31">26</sup>“Anyone who comes to me and does not
-disregard<a title="" href="part0000_split_125.html#_edn835" class="pcalibre pcalibre1" id="_ednref835"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[835]</span></span></span></a>
+disregard<a title="" href="part0000_split_125.html#_edn835" class="pcalibre pcalibre1" id="_ednref835"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[835]</span></span></span></a>
 his own father, mother, wife, children, brothers, and sisters—yes, and his own
 life also—cannot be my disciple. <sup class="calibre31">27</sup>And whoever does not bear his own
 cross and follow me cannot be my disciple. <sup class="calibre31">28</sup>For which of you,
@@ -548,7 +548,7 @@ listen!”</p>
 
 <p class="sectiontopic">The parable of the lost sheep</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_5">15</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_5">15</p>
 
 <p class="msonormal1">Now all the tax collectors and sinners were coming close to
 him to hear him. <sup class="calibre31">2</sup>But the Pharisees and scribes began to grumble,
@@ -565,7 +565,7 @@ who repents than over ninety-nine righteous who need no repentance.</p>
 
 <p class="sectiontopic">The parable of the lost coin</p>
 
-<p class="msonormal1"><sup class="calibre31">8</sup>Or what woman, if she had ten drachma<a title="" href="part0000_split_125.html#_edn836" class="pcalibre pcalibre1" id="_ednref836"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[836]</span></span></span></a>
+<p class="msonormal1"><sup class="calibre31">8</sup>Or what woman, if she had ten drachma<a title="" href="part0000_split_125.html#_edn836" class="pcalibre pcalibre1" id="_ednref836"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[836]</span></span></span></a>
 coins and lost one,<a title="" href="part0000_split_125.html#_edn837" class="pcalibre pcalibre1" id="_ednref837"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[837]</span></span></span></a>
 would not light a lamp, sweep the house, and look hard until she finds it? <sup class="calibre31">9</sup>And
 when she has found it, she calls together her friends and neighbors, saying,
@@ -625,7 +625,7 @@ He was lost and is found!’”</p>
 
 <p class="sectiontopic">The parable of the dishonest yet wise manager</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_6">16</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_6">16</p>
 
 <p class="msonormal1">Jesus also said to his disciples, “There was a certain rich
 man who had a manager. An accusation was made to him that this man was wasting
@@ -639,17 +639,17 @@ have strength to dig! I am ashamed to beg! <sup class="calibre31">4</sup>I know 
 so that when I am removed from management, people<a title="" href="part0000_split_125.html#_edn843" class="pcalibre pcalibre1" id="_ednref843"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[843]</span></span></span></a>
 may receive me into their houses.’ <sup class="calibre31">5</sup>Calling each one of his lord’s
 debtors to him, he said to the first, ‘How much do you owe to my lord?’ <sup class="calibre31">6</sup>The
-man replied, ‘A hundred measures<a title="" href="part0000_split_125.html#_edn844" class="pcalibre pcalibre1" id="_ednref844"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[844]</span></span></span></a>
+man replied, ‘A hundred measures<a title="" href="part0000_split_125.html#_edn844" class="pcalibre pcalibre1" id="_ednref844"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[844]</span></span></span></a>
 of oil.’ The manager said to him, ‘Take your bill, sit down quickly and write
 fifty.’ <sup class="calibre31">7</sup>Then he said to another, ‘How much do you owe?’ That one replied,
-‘A hundred cors<a title="" href="part0000_split_125.html#_edn845" class="pcalibre pcalibre1" id="_ednref845"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[845]</span></span></span></a>
+‘A hundred cors<a title="" href="part0000_split_125.html#_edn845" class="pcalibre pcalibre1" id="_ednref845"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[845]</span></span></span></a>
 of wheat.’ And the manager said to him, ‘Take your bill, and write eighty.’</p>
 
 <p class="msonormal1"><sup class="calibre31">8</sup>His master<a title="" href="part0000_split_125.html#_edn846" class="pcalibre pcalibre1" id="_ednref846"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[846]</span></span></span></a>
 praised the dishonest manager because he had acted wisely, for the children of
 this world are wiser than the children of the light in [dealing with] their own
 kind. <sup class="calibre31">9</sup>I tell you, make for yourselves friends by means of
-unrighteous mammon<a title="" href="part0000_split_125.html#_edn847" class="pcalibre pcalibre1" id="_ednref847"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[847]</span></span></span></a>,
+unrighteous mammon<a title="" href="part0000_split_125.html#_edn847" class="pcalibre pcalibre1" id="_ednref847"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[847]</span></span></span></a>,
 so that when you fail,<a title="" href="part0000_split_125.html#_edn848" class="pcalibre pcalibre1" id="_ednref848"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[848]</span></span></span></a>
 you may be received into the eternal dwellings. <sup class="calibre31">10</sup>Whoever is
 faithful in a very little is also faithful in much. Whoever is dishonest in
@@ -682,7 +682,7 @@ certain beggar named Lazarus was laid at his gate, full of sores, <sup class="ca
 desired to be fed with the crumbs that fell from the rich man’s table. Yes,
 even dogs came and licked his sores. <sup class="calibre31">22</sup>It happened that the beggar
 died and that he was carried away by the angels to Abraham’s bosom. The rich
-man also died, and was buried. <sup class="calibre31">23</sup>In hades,<a title="" href="part0000_split_125.html#_edn850" class="pcalibre pcalibre1" id="_ednref850"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[850]</span></span></span></a>
+man also died, and was buried. <sup class="calibre31">23</sup>In hades,<a title="" href="part0000_split_125.html#_edn850" class="pcalibre pcalibre1" id="_ednref850"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[850]</span></span></span></a>
 he lifted up his eyes, being in torment, and saw Abraham far off, and Lazarus in
 his bosom.<a title="" href="part0000_split_125.html#_edn851" class="pcalibre pcalibre1" id="_ednref851"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[851]</span></span></span></a>
 <sup class="calibre31">24</sup>He cried and said, ‘Father Abraham, have mercy on me, and send
@@ -713,7 +713,7 @@ rises from the dead.’”</p>
 
 <p class="sectiontopic">Things that cause sin—About forgiveness</p>
 
-<p class="style35ptloweredby1ptlinespacingexactly2445pt" id="toc_7">17</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_7">17</p>
 
 <p class="msonormal1"><span class="calibre71">Jesus told his
 disciples, “It is impossible that no occasions of stumbling should come, but
@@ -800,7 +800,7 @@ be assembled.”<a title="" href="part0000_split_125.html#_edn858" class="pcalib
 
 <p class="sectiontopic">The parable of the persistent widow</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_8">18</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_8">18</p>
 
 <p class="msonormal1">Jesus also told them a parable [illustrating] that they must
 always pray and not give up, <sup class="calibre31">2</sup>saying, “In a certain city, there was
@@ -930,7 +930,7 @@ praised God.</p>
 
 <p class="sectiontopic">Zacchaeus the tax collector</p>
 
-<p class="style365ptloweredby1ptlinespacingexactly2445pt" id="toc_9">19</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_9">19</p>
 
 <p class="msonormal1">Jesus entered Jericho and was passing through town. <sup class="calibre31">2</sup>There
 was a man named Zacchaeus who was a chief tax collector, and he was rich. <sup class="calibre31">3</sup>He
@@ -958,7 +958,7 @@ supposed that the Kingdom of God would be revealed immediately. <sup class="cali
 said therefore, “A certain nobleman went into a far country to receive a
 kingdom for himself, and then return. <sup class="calibre31">13</sup>So he called ten of his
 slaves,<a title="" href="part0000_split_125.html#_edn877" class="pcalibre pcalibre1" id="_ednref877"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[877]</span></span></span></a>
-gave them ten mina coins,<a title="" href="part0000_split_125.html#_edn878" class="pcalibre pcalibre1" id="_ednref878"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[878]</span></span></span></a>
+gave them ten mina coins,<a title="" href="part0000_split_125.html#_edn878" class="pcalibre pcalibre1" id="_ednref878"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[878]</span></span></span></a>
 and told them, ‘Do business [with these] until I come.’ <sup class="calibre31">14</sup>But his subjects
 hated him, and they sent a delegation after him to say: ‘We do not want this
 man to reign over us.’</p>
@@ -1046,7 +1046,7 @@ because you did not know the time of your visitation.”</p>
 
 <p class="msonormal1"><sup class="calibre31">45</sup>Then Jesus entered into the temple, and he
 began to drive out those who bought and sold in it, <sup class="calibre31">46</sup>saying to them,
-“It is written that my house is a house of prayer,<a title="" href="part0000_split_125.html#_edn890" class="pcalibre pcalibre1" id="_ednref890"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[890]</span></span></span></a>
+“It is written that my house is a house of prayer,<a title="" href="part0000_split_125.html#_edn890" class="pcalibre pcalibre1" id="_ednref890"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[890]</span></span></span></a>
 but you have made it a den of robbers!”<a title="" href="part0000_split_125.html#_edn891" class="pcalibre pcalibre1" id="_ednref891"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[891]</span></span></span></a></p>
 
 <p class="msonormal1"><sup class="calibre31">47</sup>He was teaching every day in the temple, but
@@ -1056,7 +1056,7 @@ way to do so because all the people were captured by every word that he said.</p
 
 <p class="sectiontopic">By what authority</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_10">20</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_10">20</p>
 
 <p class="msonormal1">It happened on one of those days, as he was teaching the
 people in the temple and preaching the Good News, that the <a title="" href="part0000_split_125.html#_edn892" class="pcalibre pcalibre1" id="_ednref892"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[892]</span></span></span></a>priests
@@ -1157,7 +1157,7 @@ dead do not marry or are given in marriage. <sup class="calibre31">36</sup>They 
 more, because they are like the angels, and they are children of God, being
 children of the resurrection. <sup class="calibre31">37</sup>But that the dead are raised, even
 Moses showed in the [story of the burning] bush, when he called the Lord ‘The
-God of Abraham, the God of Isaac, and the God of Jacob.’<a title="" href="part0000_split_125.html#_edn901" class="pcalibre pcalibre1" id="_ednref901"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[901]</span></span></span></a>
+God of Abraham, the God of Isaac, and the God of Jacob.’<a title="" href="part0000_split_125.html#_edn901" class="pcalibre pcalibre1" id="_ednref901"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[901]</span></span></span></a>
 <sup class="calibre31">38</sup>Now he is not the God of the dead, but of the living, because all
 are alive to him!”</p>
 
@@ -1190,7 +1190,7 @@ receive greater condemnation!”</p>
 
 <p class="sectiontopic">The gift of the poor widow</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_11">21</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_11">21</p>
 
 <p class="msonormal1"><span class="calibre27">Looking up, Jesus saw the
 rich who were putting their gifts into the treasury. <sup class="calibre31">2</sup>Then he saw a
@@ -1212,7 +1212,7 @@ these things take place? What is the sign that these things are about to
 happen?”</p>
 
 <p class="msonormal1"><sup class="calibre31">8</sup>Jesus replied, “Watch out that you do not get
-led astray, for many will come in my Name, saying: ‘I am he<a title="" href="part0000_split_125.html#_edn909" class="pcalibre pcalibre1" id="_ednref909"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[909]</span></span></span></a>,’
+led astray, for many will come in my Name, saying: ‘I am he<a title="" href="part0000_split_125.html#_edn909" class="pcalibre pcalibre1" id="_ednref909"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[909]</span></span></span></a>,’
 and, ‘The time is at hand!’ Do not follow them! <sup class="calibre31">9</sup>When you hear of
 wars and insurrections,<a title="" href="part0000_split_125.html#_edn910" class="pcalibre pcalibre1" id="_ednref910"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[910]</span></span></span></a>
 do not be terrified, for these things must happen first, but the end will not
@@ -1285,7 +1285,7 @@ him in the temple in order to listen to him.</p>
 
 <p class="sectiontopic">The plot against Jesus</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_12">22</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_12">22</p>
 
 <p class="msonormal1">Now the feast of unleavened bread, which is called the
 Passover<a title="" href="part0000_split_125.html#_edn916" class="pcalibre pcalibre1" id="_ednref916"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[916]</span></span></span></a>,
@@ -1376,7 +1376,7 @@ without purse, bag, or sandals, did you lack anything?”</p>
 <p class="msonormal1"><sup class="calibre31">36</sup>He then said to them, “But now, whoever has a
 purse should take it, and likewise a bag! Whoever has no sword should sell his
 cloak and buy one! <sup class="calibre31">37</sup>For I tell you that what is written must still
-be fulfilled in me: ‘He was counted with transgressors.’<a title="" href="part0000_split_125.html#_edn929" class="pcalibre pcalibre1" id="_ednref929"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[929]</span></span></span></a>
+be fulfilled in me: ‘He was counted with transgressors.’<a title="" href="part0000_split_125.html#_edn929" class="pcalibre pcalibre1" id="_ednref929"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[929]</span></span></span></a>
 Indeed, the things [written] concerning me are [reaching] a completion.”</p>
 
 <p class="msonormal1"><sup class="calibre31">38</sup>So the disciples exclaimed, “Lord, behold, here
@@ -1482,7 +1482,7 @@ witnesses? We ourselves have heard [it] from his own mouth!”</p>
 
 <p class="sectiontopic">Before Pilate—Before Herod</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_13">23</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_13">23</p>
 
 <p class="msonormal1">Their whole group arose and brought Jesus before Pilate. <sup class="calibre31">2</sup>They
 began to bring charges against him, saying, “We have found this man perverting
@@ -1555,7 +1555,7 @@ Instead, weep for yourselves and for your children! <sup class="calibre31">29</s
 the days are coming in which people will say, ‘Blessed are the barren, the
 wombs that never bore, and the breasts that never nursed.’ <sup class="calibre31">30</sup>Then
 people will begin to tell the mountains, ‘Fall on us!’ and to tell the hills,
-‘Cover us.’</span><a title="" href="part0000_split_125.html#_edn946" class="pcalibre pcalibre1" id="_ednref946"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre27"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre30">[946]</span></span></span></span></a><span class="calibre27"> <sup class="calibre31">31</sup>For if they do these things when the
+‘Cover us.’</span><a title="" href="part0000_split_125.html#_edn946" class="pcalibre pcalibre1" id="_ednref946"><span class="footnote-ref"><span class="calibre27"><span class="footnote-ref"><span class="calibre30">[946]</span></span></span></span></a><span class="calibre27"> <sup class="calibre31">31</sup>For if they do these things when the
 wood is green, what will be done when it is dry?”</span></p>
 
 <p class="msonormal1"><sup class="calibre31">32</sup>There were also others, two criminals, [who
@@ -1633,7 +1633,7 @@ according to the commandment.</p>
 
 <p class="sectiontopic">The Lord’s resurrection</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_14">24</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_14">24</p>
 
 <p class="msonormal1">On the first day of the week,<a title="" href="part0000_split_125.html#_edn963" class="pcalibre pcalibre1" id="_ednref963"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[963]</span></span></span></a>
 at early dawn, they and some others came to the tomb, bringing the spices which

--- a/text/part0000_split_032.html
+++ b/text/part0000_split_032.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection7">
+<div class="section">
 <div class="calibre11">
 <p class="heading1b" id="calibre_pb_51"><a class="pcalibre pcalibre1" id="_Toc425418822"></a><a class="pcalibre pcalibre1" id="_Toc425418675"></a><a class="pcalibre pcalibre1" id="_Toc425418527"></a><a class="pcalibre pcalibre1" id="_Toc290636400">INTRODUCTION
 TO<br class="calibre6"/>

--- a/text/part0000_split_033.html
+++ b/text/part0000_split_033.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection7">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_52"><a class="pcalibre pcalibre1" id="_Toc425418823"></a><a class="pcalibre pcalibre1" id="_Toc425418676"></a><a class="pcalibre pcalibre1" id="_Toc425418528">AUTHORSHIP AND DATE</a></h2>
 
 <p class="msonormal1"><span class="calibre67">The Gospel itself is

--- a/text/part0000_split_034.html
+++ b/text/part0000_split_034.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection7">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_53"><a class="pcalibre pcalibre1" id="_Toc425418824"></a><a class="pcalibre pcalibre1" id="_Toc425418677"></a><a class="pcalibre pcalibre1" id="_Toc425418529">THEME(S)</a></h2>
 
 <h3 class="calibre80"><a class="pcalibre pcalibre1" id="_Toc425418678"></a><a class="pcalibre pcalibre1" id="_Toc425418530">The High Priestly

--- a/text/part0000_split_035.html
+++ b/text/part0000_split_035.html
@@ -7,14 +7,14 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection7">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_55"><a class="pcalibre pcalibre1" id="_Toc425418825"></a><a class="pcalibre pcalibre1" id="_Toc425418682"></a><a class="pcalibre pcalibre1" id="_Toc425418534"></a><a class="pcalibre pcalibre1" id="_Toc290636401"><span id="98U-53f1c2fa46e747eea0a124c9756c4a6f" class="calibre25">(ACCORDING TO) JOHN</span>  <br class="calibre6"/>
 </a><span class="calibre62">(ΚΑΤΑ
 ΙΩΑΝΝΗΝ)</span></h1>
 
 <p class="sectiontopic">Prologue: The Logos/Word of God</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">In the beginning was the Word,<a title="" href="part0000_split_125.html#_edn1003" class="pcalibre pcalibre1" id="_ednref1003"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1003]</span></span></span></a>
 and the Word was with God, and the Word was {what} God<a title="" href="part0000_split_125.html#_edn1004" class="pcalibre pcalibre1" id="_ednref1004"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1004]</span></span></span></a>
@@ -155,7 +155,7 @@ the Son of Man.”</p>
 <p class="sectiontopic">The wedding at Cana—First sign: the water changed into
 wine</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">The third day, there was a wedding in Cana of Galilee, and
 the mother of Jesus was there. <sup class="calibre31">2</sup>Jesus also was invited with his
@@ -218,7 +218,7 @@ about man, for he himself knew what was in man.</p>
 
 <p class="sectiontopic">Dialogue with Nicodemus—The new birth</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">Now there was one of the Pharisees named Nicodemus, a leader
 of the Jews. <sup class="calibre31">2</sup>He came to Jesus<a title="" href="part0000_split_125.html#_edn1039" class="pcalibre pcalibre1" id="_ednref1039"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1039]</span></span></span></a>
@@ -238,7 +238,7 @@ be born? Can one enter a second time into his mother’s womb, and be born
 one is born of water and spirit, he cannot enter into the Kingdom of God! <sup class="calibre31">6</sup>What
 is born of the flesh is flesh. What is born of the Spirit<a title="" href="part0000_split_125.html#_edn1041" class="pcalibre pcalibre1" id="_ednref1041"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1041]</span></span></span></a>
 is spirit. <sup class="calibre31">7</sup>Do not marvel that I said to you, ‘You must be born
-anew.’ <sup class="calibre31">8</sup>The wind<a title="" href="part0000_split_125.html#_edn1042" class="pcalibre pcalibre1" id="_ednref1042"><span class="msoendnotereference"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1042]</span></span></span></a>
+anew.’ <sup class="calibre31">8</sup>The wind<a title="" href="part0000_split_125.html#_edn1042" class="pcalibre pcalibre1" id="_ednref1042"><span class="msoendnotereference"><span class="footnote-ref"><span class="calibre28">[1042]</span></span></span></a>
 blows where it wants to, and you hear its sound, but do not know where it comes
 from and where it is going. So it is with everyone who is born of the Spirit.”</p>
 
@@ -308,7 +308,7 @@ the Son will not see life; instead, the wrath of God remains on such a person.</
 
 <p class="sectiontopic">The Samaritan woman</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">4</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_4">4</p>
 
 <p class="msonormal1">Then, when the Lord<a title="" href="part0000_split_125.html#_edn1056" class="pcalibre pcalibre1" id="_ednref1056"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1056]</span></span></span></a>
 learned that the Pharisees had heard, “Jesus is making and baptizing more
@@ -440,7 +440,7 @@ the second sign that Jesus performed on his return from Judea into Galilee.</spa
 
 <p class="sectiontopic">The healing at the pool on the Sabbath: the third sign</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_5">5</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_5">5</p>
 
 <p class="msonormal1">After these things, there was a feast of the Jews, and Jesus
 went up to Jerusalem. <sup class="calibre31">2</sup>Now in Jerusalem, by the sheep gate, there is
@@ -559,7 +559,7 @@ you believe my words?”</p>
 
 <p class="sectiontopic">The multiplication of the five loaves: the fourth sign</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_6">6</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_6">6</p>
 
 <p class="msonormal1">After these things, Jesus went away to the other side of the
 sea of Galilee (or [also called] Tiberias). <sup class="calibre31">2</sup>A great multitude
@@ -602,7 +602,7 @@ a great wind was blowing, the sea became rough. <sup class="calibre31">19</sup>A
 three or four miles,<a title="" href="part0000_split_125.html#_edn1092" class="pcalibre pcalibre1" id="_ednref1092"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1092]</span></span></span></a>
 the disciples<a title="" href="part0000_split_125.html#_edn1093" class="pcalibre pcalibre1" id="_ednref1093"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1093]</span></span></span></a>
 saw Jesus walking on the sea and approaching the boat. And they were
-frightened, <sup class="calibre31">20</sup>but Jesus said to them, “It is I!<a title="" href="part0000_split_125.html#_edn1094" class="pcalibre pcalibre1" id="_ednref1094"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1094]</span></span></span></a>
+frightened, <sup class="calibre31">20</sup>but Jesus said to them, “It is I!<a title="" href="part0000_split_125.html#_edn1094" class="pcalibre pcalibre1" id="_ednref1094"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1094]</span></span></span></a>
 Do not be afraid!” <sup class="calibre31">21</sup>At this, they were willing to receive him into
 the boat, and immediately, the boat reached the shore where they were going.</p>
 
@@ -668,7 +668,7 @@ How then does he say, ‘I have come down out of heaven?’”</p>
 among yourselves. <sup class="calibre31">44</sup>No one can come to me unless the Father who sent
 me draws him, and this one I will raise up on<a title="" href="part0000_split_125.html#_edn1102" class="pcalibre pcalibre1" id="_ednref1102"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1102]</span></span></span></a>
 the last day. <sup class="calibre31">45</sup>It is written in the prophets, ‘And they will all be
-taught by God.’<a title="" href="part0000_split_125.html#_edn1103" class="pcalibre pcalibre1" id="_ednref1103"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1103]</span></span></span></a>
+taught by God.’<a title="" href="part0000_split_125.html#_edn1103" class="pcalibre pcalibre1" id="_ednref1103"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1103]</span></span></span></a>
 Therefore, everyone who hears from the Father and has learned comes to me. <sup class="calibre31">46</sup>Not
 that anyone has seen the Father, except he who is from God. He has seen the
 Father! <sup class="calibre31">47</sup>Amen, amen, I tell you; the one who believes in me<a title="" href="part0000_split_125.html#_edn1104" class="pcalibre pcalibre1" id="_ednref1104"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1104]</span></span></span></a>
@@ -727,7 +727,7 @@ being one of the Twelve.</p>
 
 <p class="sectiontopic">The Feast of Tabernacles </p>
 
-<p class="style35ptloweredby1ptlinespacingexactly2445pt" id="toc_7">7</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_7">7</p>
 
 <p class="msonormal1">After these things, Jesus went about in Galilee; he did not
 wish to travel around in Judea because the Jews were seeking to kill him. <sup class="calibre31">2</sup>Now
@@ -855,7 +855,7 @@ Search, and see that no prophet has arisen out of Galilee.”<a title="" href="p
 
 <p class="sectiontopic">The woman caught in adultery</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_8">8</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_8">8</p>
 
 <p class="msonormal1">But Jesus went to the Mount of Olives. <sup class="calibre31">2</sup>Now at
 daybreak, he appeared again in the temple, and all the people came to him. He
@@ -886,7 +886,7 @@ now on, sin no more.” &gt;&gt;</p>
 <p class="sectiontopic">The Light of the world—Witnesses to Jesus</p>
 
 <p class="msonormal1"><sup class="calibre31">12</sup>Then again, Jesus spoke to them, saying, “I am
-the light of the world.<a title="" href="part0000_split_125.html#_edn1137" class="pcalibre pcalibre1" id="_ednref1137"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1137]</span></span></span></a>
+the light of the world.<a title="" href="part0000_split_125.html#_edn1137" class="pcalibre pcalibre1" id="_ednref1137"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1137]</span></span></span></a>
 Whoever follows me will not walk in the darkness but will have the light of
 life.”</p>
 
@@ -898,7 +898,7 @@ myself, my testimony is true, because I know where I came from and where I am
 going. But you do not know where I came from or where I am going. <sup class="calibre31">15</sup>You
 judge according to the flesh. I judge no one. <sup class="calibre31">16</sup>Even if I do judge,
 my judgment is true, for I am not alone, but I am with the Father who sent me. <sup class="calibre31">17</sup>It
-is also written in your law that the testimony of two people is truthful.<a title="" href="part0000_split_125.html#_edn1139" class="pcalibre pcalibre1" id="_ednref1139"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1139]</span></span></span></a>
+is also written in your law that the testimony of two people is truthful.<a title="" href="part0000_split_125.html#_edn1139" class="pcalibre pcalibre1" id="_ednref1139"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1139]</span></span></span></a>
 <sup class="calibre31">18</sup>I am one who testifies about myself, and the Father who sent me [also]
 bears witness to me.”</p>
 
@@ -917,7 +917,7 @@ since he says, ‘Where I am going, you cannot come?’”</p>
 
 <p class="msonormal1"><sup class="calibre31">23</sup>Jesus said to them, “You are from below; I am
 from above. You are of this world; I am not of this world. <sup class="calibre31">24</sup>I told
-you therefore that you will die in your sins; for unless you believe that I am<a title="" href="part0000_split_125.html#_edn1140" class="pcalibre pcalibre1" id="_ednref1140"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1140]</span></span></span></a>
+you therefore that you will die in your sins; for unless you believe that I am<a title="" href="part0000_split_125.html#_edn1140" class="pcalibre pcalibre1" id="_ednref1140"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1140]</span></span></span></a>
 {the one},<a title="" href="part0000_split_125.html#_edn1141" class="pcalibre pcalibre1" id="_ednref1141"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1141]</span></span></span></a>
 you will die in your sins.”</p>
 
@@ -1004,7 +1004,7 @@ was glad!”</p>
 fifty years old, and you have seen Abraham?”</p>
 
 <p class="msonormal1"><sup class="calibre31">58</sup>Jesus said to them, “Amen, amen, I tell you;
-before Abraham came into existence, I am.<a title="" href="part0000_split_125.html#_edn1151" class="pcalibre pcalibre1" id="_ednref1151"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1151]</span></span></span></a>”</p>
+before Abraham came into existence, I am.<a title="" href="part0000_split_125.html#_edn1151" class="pcalibre pcalibre1" id="_ednref1151"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1151]</span></span></span></a>”</p>
 
 <p class="msonormal1"><sup class="calibre31">59</sup>Therefore, they took up stones to throw at him,
 but Jesus was hidden, and &lt;having gone through their midst and so passing
@@ -1013,7 +1013,7 @@ he went out of the temple.</p>
 
 <p class="sectiontopic">The healing of the man born blind: the fifth sign</p>
 
-<p class="style365ptloweredby1ptlinespacingexactly2445pt" id="toc_9">9</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_9">9</p>
 
 <p class="msonormal1">As Jesus<a title="" href="part0000_split_125.html#_edn1153" class="pcalibre pcalibre1" id="_ednref1153"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1153]</span></span></span></a>
 was passing by, he saw a man blind from birth. <sup class="calibre31">2</sup>His disciples asked
@@ -1123,7 +1123,7 @@ would have no sin; but now you say, ‘We see!’ and therefore, your sin remain
 
 <p class="sectiontopic">The good shepherd</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_10">10</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_10">10</p>
 
 <p class="msonormal1">“Amen, amen, I tell you; whoever does not enter by the gate
 into the sheep fold, but climbs up some other way is a thief and a robber. <sup class="calibre31">2</sup>But
@@ -1143,7 +1143,7 @@ me are thieves and robbers, but the sheep did not listen to them. <sup class="ca
 am the gate! Anyone who enters in by me will be saved, and go in and out, and
 will find pasture. <sup class="calibre31">10</sup>The thief only comes to steal, kill, and
 destroy. I came so that people may have life, and have it in abundance. <sup class="calibre31">11</sup>I
-am the good shepherd!<a title="" href="part0000_split_125.html#_edn1164" class="pcalibre pcalibre1" id="_ednref1164"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1164]</span></span></span></a>
+am the good shepherd!<a title="" href="part0000_split_125.html#_edn1164" class="pcalibre pcalibre1" id="_ednref1164"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1164]</span></span></span></a>
 The good shepherd lays down his life for the sheep. <sup class="calibre31">12</sup>The one who is
 a hired hand, not a shepherd, and who does not own the sheep, leaves the sheep
 and flees when he sees the wolf coming. Then the wolf snatches the sheep and
@@ -1151,10 +1151,10 @@ scatters them. <sup class="calibre31">13</sup>The hired hand flees because he is
 does not care for the sheep. <sup class="calibre31">14</sup>I am the good shepherd! I know my own,
 and I am known by my own; <sup class="calibre31">15</sup>even as the Father knows me, and I know
 the Father. I lay down my life for the sheep. <sup class="calibre31">16</sup>I have other sheep,
-which are not of this fold.<a title="" href="part0000_split_125.html#_edn1165" class="pcalibre pcalibre1" id="_ednref1165"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1165]</span></span></span></a>
+which are not of this fold.<a title="" href="part0000_split_125.html#_edn1165" class="pcalibre pcalibre1" id="_ednref1165"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1165]</span></span></span></a>
 I must bring them also, and they will hear my voice. And there will be one
 flock—one shepherd. <sup class="calibre31">17</sup>Therefore, the Father loves me, because I lay
-down my life,<a title="" href="part0000_split_125.html#_edn1166" class="pcalibre pcalibre1" id="_ednref1166"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1166]</span></span></span></a>
+down my life,<a title="" href="part0000_split_125.html#_edn1166" class="pcalibre pcalibre1" id="_ednref1166"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1166]</span></span></span></a>
 so that I may take it again. <sup class="calibre31">18</sup>No one takes my life<a title="" href="part0000_split_125.html#_edn1167" class="pcalibre pcalibre1" id="_ednref1167"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1167]</span></span></span></a>
 away from me, but I lay it down of my own accord. I have power to lay it down,
 and I have power to take it again.<a title="" href="part0000_split_125.html#_edn1168" class="pcalibre pcalibre1" id="_ednref1168"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1168]</span></span></span></a>
@@ -1192,7 +1192,7 @@ do you stone me?”</p>
 a good work, but for blasphemy: because you, being a man, make yourself God.”<a title="" href="part0000_split_125.html#_edn1171" class="pcalibre pcalibre1" id="_ednref1171"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1171]</span></span></span></a></p>
 
 <p class="msonormal1"><sup class="calibre31">34</sup>Jesus answered them, “Is it not written in your
-law, ‘I said, you are gods?’<a title="" href="part0000_split_125.html#_edn1172" class="pcalibre pcalibre1" id="_ednref1172"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1172]</span></span></span></a>
+law, ‘I said, you are gods?’<a title="" href="part0000_split_125.html#_edn1172" class="pcalibre pcalibre1" id="_ednref1172"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1172]</span></span></span></a>
 <sup class="calibre31">35</sup>If he called them gods, (those to whom the word of God came, and
 the Scripture cannot be broken), <sup class="calibre31">36</sup>do you say of him whom the Father
 has consecrated<a title="" href="part0000_split_125.html#_edn1173" class="pcalibre pcalibre1" id="_ednref1173"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1173]</span></span></span></a>
@@ -1210,7 +1210,7 @@ about this man is true!” <sup class="calibre31">42</sup>And many believed in h
 
 <p class="sectiontopic">The raising of Lazarus: the sixth sign</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_11">11</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_11">11</p>
 
 <p class="msonormal1">Now a certain man was sick, Lazarus of Bethany, the village
 of Mary and her sister, Martha. <sup class="calibre31">2</sup>It was that [same] Mary who had
@@ -1350,7 +1350,7 @@ report it, so that they might arrest him.</p>
 
 <p class="sectiontopic">The anointing at Bethany</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_12">12</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_12">12</p>
 
 <p class="msonormal1">Six days before the Passover, Jesus came to Bethany where
 Lazarus (who had been dead and whom Jesus<a title="" href="part0000_split_125.html#_edn1186" class="pcalibre pcalibre1" id="_ednref1186"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1186]</span></span></span></a>
@@ -1488,7 +1488,7 @@ what the Father has told me is what I speak.”</p>
 
 <p class="sectiontopic">The washing of the disciples’ feet</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_13">13</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_13">13</p>
 
 <p class="msonormal1">Now [it was just] before the feast of the Passover. Jesus
 knew that his time had come for him to depart from this world to the Father.
@@ -1529,7 +1529,7 @@ his master; neither is the one who is sent greater than he who sent him. <sup cl
 that you know these things, blessed are you if you do them! <sup class="calibre31">18</sup>I do
 not speak about all of you; I know whom I have chosen. But it is in order that
 the Scripture may be fulfilled, ‘He who eats bread with me has lifted up his
-heel against me.’</span><a title="" href="part0000_split_125.html#_edn1206" class="pcalibre pcalibre1" id="_ednref1206"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre27"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre30">[1206]</span></span></span></span></a><span class="calibre27"> <sup class="calibre31">19</sup>From now on, I tell you before it
+heel against me.’</span><a title="" href="part0000_split_125.html#_edn1206" class="pcalibre pcalibre1" id="_ednref1206"><span class="footnote-ref"><span class="calibre27"><span class="footnote-ref"><span class="calibre30">[1206]</span></span></span></span></a><span class="calibre27"> <sup class="calibre31">19</sup>From now on, I tell you before it
 happens, so that when it happens, you may believe that I am {he}.<a title="" href="part0000_split_125.html#_edn1207" class="pcalibre pcalibre1" id="_ednref1207"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre30">[1207]</span></span></span></a> <sup class="calibre31">20</sup>Amen, amen,
 I tell you; whoever receives one whom I send receives me; and whoever receives
 me receives the one who sent me.”</span></p>
@@ -1589,7 +1589,7 @@ me three times!”</p>
 
 <p class="sectiontopic">Discourse at the Last Supper—‘Many mansions’</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_14">14</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_14">14</p>
 
 <p class="msonormal1">“Do not let your heart be troubled. Have faith in God! Have
 faith also in me! <sup class="calibre31">2</sup>In my Father’s house are many mansions.<a title="" href="part0000_split_125.html#_edn1211" class="pcalibre pcalibre1" id="_ednref1211"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1211]</span></span></span></a>
@@ -1626,7 +1626,7 @@ it.<a title="" href="part0000_split_125.html#_edn1212" class="pcalibre pcalibre1
 <p class="sectiontopic">The Counselor (Paraclete)—Peace</p>
 
 <p class="msonormal1"><sup class="calibre31">16</sup>I will pray to the Father and he will give you
-another Counselor<a title="" href="part0000_split_125.html#_edn1214" class="pcalibre pcalibre1" id="_ednref1214"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1214]</span></span></span></a>
+another Counselor<a title="" href="part0000_split_125.html#_edn1214" class="pcalibre pcalibre1" id="_ednref1214"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1214]</span></span></span></a>
 to be with you forever,<sup class="calibre31">17</sup>the Spirit of truth. The world cannot
 receive him because it does not see him and does not know him. But you know him,
 because he lives with you and will be in you. <sup class="calibre31">18</sup>I will not leave you
@@ -1661,7 +1661,7 @@ me. Arise, let us be on our way!”</p>
 
 <p class="sectiontopic">The vine and the branches</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_15">15</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_15">15</p>
 
 <p class="msonormal1"><span class="calibre27">“I am the true vine, and
 my Father is the vinedresser. <sup class="calibre31">2</sup>Every branch in me that does not bear
@@ -1705,7 +1705,7 @@ Paraclete</p>
 hated me before it hated you. <sup class="calibre31">19</sup>If you were of the world, the world
 would love its own! But you are not of the world, since I chose you out of the
 world, and so the world hates you. <sup class="calibre31">20</sup>Remember what I told you: ‘A bondservant
-is not greater than his lord.’<a title="" href="part0000_split_125.html#_edn1222" class="pcalibre pcalibre1" id="_ednref1222"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1222]</span></span></span></a>
+is not greater than his lord.’<a title="" href="part0000_split_125.html#_edn1222" class="pcalibre pcalibre1" id="_ednref1222"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1222]</span></span></span></a>
 If they persecuted me, they will also persecute you. If they kept my word, they
 will also keep yours. <sup class="calibre31">21</sup>But they will do all these things to you on
 account of my Name, because they do not know the one who sent me. <sup class="calibre31">22</sup>If
@@ -1715,9 +1715,9 @@ Father. <sup class="calibre31">24</sup>If I had not accomplished among them the 
 one else had done [before], they would not have had sin. But now, they have
 seen [those things] and yet they have hated both me and my Father. <sup class="calibre31">25</sup>But
 this has happened so that the word which was written in their law may be
-fulfilled: ‘They hated me without reason.’<a title="" href="part0000_split_125.html#_edn1223" class="pcalibre pcalibre1" id="_ednref1223"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1223]</span></span></span></a></p>
+fulfilled: ‘They hated me without reason.’<a title="" href="part0000_split_125.html#_edn1223" class="pcalibre pcalibre1" id="_ednref1223"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1223]</span></span></span></a></p>
 
-<p class="msonormal1"><sup class="calibre31">26</sup>But when the Counselor<a title="" href="part0000_split_125.html#_edn1224" class="pcalibre pcalibre1" id="_ednref1224"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1224]</span></span></span></a>
+<p class="msonormal1"><sup class="calibre31">26</sup>But when the Counselor<a title="" href="part0000_split_125.html#_edn1224" class="pcalibre pcalibre1" id="_ednref1224"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1224]</span></span></span></a>
 has come, whom I will send<a title="" href="part0000_split_125.html#_edn1225" class="pcalibre pcalibre1" id="_ednref1225"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1225]</span></span></span></a>
 to you from the Father, the Spirit of truth who proceeds<a title="" href="part0000_split_125.html#_edn1226" class="pcalibre pcalibre1" id="_ednref1226"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1226]</span></span></span></a>
 from the Father, he will bear witness to me. <sup class="calibre31">27</sup>You also will bear
@@ -1725,12 +1725,12 @@ witness, because you have been with me from the beginning.”</p>
 
 <p class="sectiontopic">Persecutions—The Lord’s departure announced</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_16">16</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_16">16</p>
 
 <p class="msonormal1">“I have told you these things, so that you would not be made
 to stumble. <sup class="calibre31">2</sup>They will expel you from the synagogues! Yes, the time is
 coming when whoever kills you will think that he is offering {divine} service<a title="" href="part0000_split_125.html#_edn1227" class="pcalibre pcalibre1" id="_ednref1227"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1227]</span></span></span></a>
-to God! <sup class="calibre31">3</sup>They will do these things<a title="" href="part0000_split_125.html#_edn1228" class="pcalibre pcalibre1" id="_ednref1228"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1228]</span></span></span></a>
+to God! <sup class="calibre31">3</sup>They will do these things<a title="" href="part0000_split_125.html#_edn1228" class="pcalibre pcalibre1" id="_ednref1228"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1228]</span></span></span></a>
 because they have not known the Father or me. <sup class="calibre31">4</sup>But I have told you
 these things, so that when the time arrives, you may remember that I told you
 about them. I did not tell you these things from the beginning because I was
@@ -1751,7 +1751,7 @@ come, he will guide you into all truth because he will not speak from himself,
 but whatever he hears, he will speak. He will tell you of things that are yet
 to come. <sup class="calibre31">14</sup>He will glorify me by taking from what is mine, and he will
 declare it to you. <sup class="calibre31">15</sup>Everything the Father has is mine; therefore I
-said that he will take<a title="" href="part0000_split_125.html#_edn1229" class="pcalibre pcalibre1" id="_ednref1229"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1229]</span></span></span></a>
+said that he will take<a title="" href="part0000_split_125.html#_edn1229" class="pcalibre pcalibre1" id="_ednref1229"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1229]</span></span></span></a>
 of [what is] mine and will declare it to you. <sup class="calibre31">16</sup>In a little while, you
 will not see me, and then after a little while you will see me because I go to
 the Father.”<a title="" href="part0000_split_125.html#_edn1230" class="pcalibre pcalibre1" id="_ednref1230"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1230]</span></span></span></a></p>
@@ -1801,7 +1801,7 @@ overcome the world.”</span></p>
 
 <p class="sectiontopic">The ‘high priestly’ prayer</p>
 
-<p class="style35ptloweredby1ptlinespacingexactly2445pt" id="toc_17">17</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_17">17</p>
 
 <p class="msonormal1">Jesus said these things, and lifting up his eyes to heaven,
 he said, “Father, the time has come! Glorify your Son, so that your Son may
@@ -1835,7 +1835,7 @@ world has hated them because they are not of the world, even as I am not of the
 world. <sup class="calibre31">15</sup>I do not pray that you would take them from the world, but
 that you would protect<a title="" href="part0000_split_125.html#_edn1237" class="pcalibre pcalibre1" id="_ednref1237"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1237]</span></span></span></a>
 them from the evil one. <sup class="calibre31">16</sup>They are not of the world, even as I am
-not of the world. <sup class="calibre31">17</sup>Sanctify them in your truth; your word is truth!<a title="" href="part0000_split_125.html#_edn1238" class="pcalibre pcalibre1" id="_ednref1238"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1238]</span></span></span></a>
+not of the world. <sup class="calibre31">17</sup>Sanctify them in your truth; your word is truth!<a title="" href="part0000_split_125.html#_edn1238" class="pcalibre pcalibre1" id="_ednref1238"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1238]</span></span></span></a>
 <sup class="calibre31">18</sup>As you sent me into the world, I too have sent them into the
 world. <sup class="calibre31">19</sup>I sanctify myself for their sake, so that they too may be
 sanctified in truth. <sup class="calibre31">20</sup>I do not pray only for these, but also for
@@ -1855,7 +1855,7 @@ them, and I in them.”</p>
 
 <p class="sectiontopic">The Lord is arrested in the garden—Peter and his sword</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_18">18</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_18">18</p>
 
 <p class="msonormal1">After speaking these words, Jesus<a title="" href="part0000_split_125.html#_edn1240" class="pcalibre pcalibre1" id="_ednref1240"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1240]</span></span></span></a>
 went out with his disciples over the brook [called] Kidron. A garden<a title="" href="part0000_split_125.html#_edn1241" class="pcalibre pcalibre1" id="_ednref1241"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1241]</span></span></span></a>
@@ -1991,7 +1991,7 @@ Barabbas!” Now Barabbas was a rebel.</p>
 
 <p class="sectiontopic">The Lord is flogged, mocked, condemned</p>
 
-<p class="style365ptloweredby1ptlinespacingexactly2445pt" id="toc_19">19</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_19">19</p>
 
 <p class="msonormal1">Then Pilate took Jesus and had him flogged. <sup class="calibre31">2</sup>The
 soldiers twisted thorns into a crown, placed it on his head, and dressed him in
@@ -2120,7 +2120,7 @@ Jesus there.</p>
 
 <p class="sectiontopic">The empty tomb—Appearance to Mary Magdalene</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_20">20</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_20">20</p>
 
 <p class="msonormal1">Now on the first [day] of the week,<a title="" href="part0000_split_125.html#_edn1261" class="pcalibre pcalibre1" id="_ednref1261"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1261]</span></span></span></a>
 Mary Magdalene went to the tomb early, while it was still dark. She saw that
@@ -2203,7 +2203,7 @@ here and put it into my side. Do not be unbelieving, but believing!”</p>
 
 <p class="msonormal1"><sup class="calibre31">28</sup>And Thomas answered him, “My Lord and my God!”</p>
 
-<p class="msonormal1"><sup class="calibre31">29</sup>Jesus said to him, “Because you have seen me,<a title="" href="part0000_split_125.html#_edn1271" class="pcalibre pcalibre1" id="_ednref1271"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1271]</span></span></span></a>
+<p class="msonormal1"><sup class="calibre31">29</sup>Jesus said to him, “Because you have seen me,<a title="" href="part0000_split_125.html#_edn1271" class="pcalibre pcalibre1" id="_ednref1271"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1271]</span></span></span></a>
 you have believed. Blessed are those who have not seen, and have believed.”</p>
 
 <p class="sectiontopic">The Author’s Purpose</p>
@@ -2215,7 +2215,7 @@ God, and that believing, you may have life in his Name.</p>
 
 <p class="sectiontopic">Appearance at the Lake </p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_21">21</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_21">21</p>
 
 <p class="msonormal1">After these things, Jesus manifested himself again to the
 disciples at the sea of Tiberias. He manifested himself in this way: <sup class="calibre31">2</sup>Simon

--- a/text/part0000_split_036.html
+++ b/text/part0000_split_036.html
@@ -7,14 +7,14 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection7">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_57"><a class="pcalibre pcalibre1" id="_Toc425418826"></a><a class="pcalibre pcalibre1" id="_Toc425418683"></a><a class="pcalibre pcalibre1" id="_Toc425418535"></a><a class="pcalibre pcalibre1" id="_Toc290636402"><span id="BMC-53f1c2fa46e747eea0a124c9756c4a6f" class="calibre25">ACTS OF THE APOSTLES</span>  <br class="calibre6"/>
 </a><span class="calibre62">(ΠΡΑΞΕΙΣ
 ΤΩΝ ΑΠΟΣΤΟΛΩΝ)</span></h1>
 
 <p class="sectiontopic">The promise of the Spirit—The Lord’s Ascension</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">The first book I wrote, Theophilus, dealt with all that
 Jesus did and taught from the beginning, <sup class="calibre31">2</sup>until the day in which he
@@ -101,7 +101,7 @@ apostles.</p>
 
 <p class="sectiontopic">Pentecost, the coming of the Holy Spirit</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">Now when the day of Pentecost came, they were all with one
 accord [gathered] in the same place. <sup class="calibre31">2</sup>Suddenly, there came from
@@ -243,7 +243,7 @@ Church those who were being saved.</p>
 
 <p class="sectiontopic">The healing of a beggar at the temple gate</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">Peter and John would go up into the temple at the hour of
 prayer, the ninth hour.<a title="" href="part0000_split_125.html#_edn1311" class="pcalibre pcalibre1" id="_ednref1311"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1311]</span></span></span></a>
@@ -307,7 +307,7 @@ ways.”</p>
 
 <p class="sectiontopic">Peter and John arrested</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">4</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_4">4</p>
 
 <p class="msonormal1">As they were speaking to the people, the priests, the
 captain of the temple, and the Sadducees came to them. <sup class="calibre31">2</sup>They were
@@ -415,7 +415,7 @@ owned and brought the money, laying it at the apostles’ feet.</p>
 
 <p class="sectiontopic">The death of Ananias and Sapphira </p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_5">5</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_5">5</p>
 
 <p class="msonormal1">Now a certain man named Ananias, along with his wife
 Sapphira, [also] sold a possession. <sup class="calibre31">2</sup>He kept back part of the price
@@ -529,7 +529,7 @@ never stopped teaching and preaching that Jesus is the Christ.</p>
 <p class="sectiontopic">The apostles appoint seven assistants—About Stephen
 (Stephanos)</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_6">6</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_6">6</p>
 
 <p class="msonormal1">Now in those days, when the number of the disciples was
 multiplying, a complaint arose from the Hellenists<a title="" href="part0000_split_125.html#_edn1345" class="pcalibre pcalibre1" id="_ednref1345"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1345]</span></span></span></a>
@@ -568,7 +568,7 @@ and saw that his face was like the face of an angel.</p>
 
 <p class="sectiontopic">Stephen’s discourse </p>
 
-<p class="style35ptloweredby1ptlinespacingexactly2445pt" id="toc_7">7</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_7">7</p>
 
 <p class="msonormal1">The high priest asked, “Are these things so?”</p>
 
@@ -727,7 +727,7 @@ this sin against them!” Having said this, he fell asleep.</p>
 
 <p class="sectiontopic">Persecution against the Church</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_8">8</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_8">8</p>
 
 <p class="msonormal1">Now Saul was in full agreement with Stephen’s<a title="" href="part0000_split_125.html#_edn1373" class="pcalibre pcalibre1" id="_ednref1373"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1373]</span></span></span></a>
 death. At that time, a great persecution arose against the Church which was in
@@ -843,7 +843,7 @@ reached Caesarea.</p>
 
 <p class="sectiontopic">Road to Damascus: Saul’s conversion and baptism</p>
 
-<p class="style365ptloweredby1ptlinespacingexactly2445pt" id="toc_9">9</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_9">9</p>
 
 <p class="msonormal1"><span class="calibre27">But Saul, still breathing
 threats and slaughter against the disciples of the Lord, went to the high
@@ -856,7 +856,7 @@ Saul, why are you persecuting me?”</span></p>
 
 <p class="msonormal1"><sup class="calibre31">5</sup>He asked, “Who are you, Lord?”</p>
 
-<p class="msonormal1">The Lord answered, “I am Jesus, whom you are persecuting.<a title="" href="part0000_split_125.html#_edn1385" class="pcalibre pcalibre1" id="_ednref1385"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1385]</span></span></span></a>
+<p class="msonormal1">The Lord answered, “I am Jesus, whom you are persecuting.<a title="" href="part0000_split_125.html#_edn1385" class="pcalibre pcalibre1" id="_ednref1385"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1385]</span></span></span></a>
 <sup class="calibre31">6</sup>Now arise, go into the city, and [there] you will be told what you
 must do.”</p>
 
@@ -873,7 +873,7 @@ Damascus. In a vision, the Lord said to him, “Ananias!”</p>
 <p class="msonormal1">Ananias answered, “Behold, I [am here] Lord!”</p>
 
 <p class="msonormal1"><sup class="calibre31">11</sup>The Lord said to him, “Arise, and go to the
-street which is called Straight, and inquire in the house of Judah<a title="" href="part0000_split_125.html#_edn1388" class="pcalibre pcalibre1" id="_ednref1388"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[1388]</span></span></span></a>
+street which is called Straight, and inquire in the house of Judah<a title="" href="part0000_split_125.html#_edn1388" class="pcalibre pcalibre1" id="_ednref1388"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[1388]</span></span></span></a>
 for someone named Saul, a man of Tarsus. For behold, he is praying, <sup class="calibre31">12</sup>and
 in a vision he has seen a man named Ananias coming in and laying his hands on
 him, so that he might receive his sight.”</p>
@@ -959,7 +959,7 @@ stayed in Joppa for a while, lodging with Simon, a tanner.</p>
 
 <p class="sectiontopic">Cornelius receives a vision</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_10">10</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_10">10</p>
 
 <p class="msonormal1">Now there was a certain man in Caesarea whose name was
 Cornelius. He was a centurion of what was called the Italian Regiment, <sup class="calibre31">2</sup>a
@@ -1077,7 +1077,7 @@ him to stay for a few days.</p>
 <p class="sectiontopic">Peter returns to Jerusalem—He explains his actions in
 Caesarea </p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_11">11</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_11">11</p>
 
 <p class="msonormal1">Now the apostles and the brethren who were in Judea heard
 that the Gentiles had also received the word of God. <sup class="calibre31">2</sup>When Peter
@@ -1144,7 +1144,7 @@ Barnabas and Saul.</p>
 
 <p class="sectiontopic">Herod’s persecution—James is martyred</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_12">12</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_12">12</p>
 
 <p class="msonormal1">About that time, King Herod took actions to oppress some of
 the [members of the] Church. <sup class="calibre31">2</sup>He had James, the brother of John,
@@ -1216,7 +1216,7 @@ was Mark.</p>
 
 <p class="msonormal10"> </p>
 
-<p class="style375ptbefore0ptloweredby7ptlinespacingexac" id="toc_13">13</p>
+<p class="chapter-number chapter-number--nudge-7" id="toc_13">13</p>
 
 <p class="msonormal1">Now in the Church that was at Antioch, there were some
 prophets and teachers: Barnabas, Simeon who was surnamed Niger, Lucius of
@@ -1353,7 +1353,7 @@ the disciples were filled with joy and [with] the Holy Spirit.</p>
 
 <p class="sectiontopic">In Iconium and Lystra</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_14">14</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_14">14</p>
 
 <p class="msonormal1">In Iconium, both Paul and Barnabas entered into the
 synagogue of the Jews. They spoke in such a way that a great multitude of both
@@ -1418,7 +1418,7 @@ accomplished with them, and that he had opened a door of faith to the Gentiles.
 
 <p class="sectiontopic">The council in Jerusalem</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_15">15</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_15">15</p>
 
 <p class="msonormal1">Then certain men came down from Judea {to Antioch} and
 taught the brethren,<a title="" href="part0000_split_125.html#_edn1453" class="pcalibre pcalibre1" id="_ednref1453"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1453]</span></span></span></a>
@@ -1534,7 +1534,7 @@ went through Syria and Cilicia, strengthening the Churches.</p>
 
 <p class="sectiontopic">About Timothy</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_16">16</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_16">16</p>
 
 <p class="msonormal1">Paul then came to Derbe and Lystra. And behold, a certain
 disciple named Timothy lived there. He was the son of a certain Jewish woman
@@ -1641,7 +1641,7 @@ they met the brethren and encouraged them. Then they departed.</p>
 
 <p class="sectiontopic">Paul in Thessalonica </p>
 
-<p class="style35ptloweredby1ptlinespacingexactly2445pt" id="toc_17">17</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_17">17</p>
 
 <p class="msonormal1">After passing through Amphipolis and Apollonia, Paul and
 Silas arrived in Thessalonica where there was a Jewish synagogue. <sup class="calibre31">2</sup>As
@@ -1736,7 +1736,7 @@ a woman named Damaris and others with them.</p>
 
 <p class="sectiontopic">Paul in Corinth </p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_18">18</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_18">18</p>
 
 <p class="msonormal1">After this, Paul left Athens and went to Corinth. <sup class="calibre31">2</sup>There,
 he met a certain Jew named Aquila, a man of Pontus by race. He and his wife
@@ -1816,7 +1816,7 @@ was the Christ.</p>
 
 <p class="sectiontopic">Paul in Ephesus—Baptism and the Holy Spirit—Miracles</p>
 
-<p class="style365ptloweredby1ptlinespacingexactly2445pt" id="toc_19">19</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_19">19</p>
 
 <p class="msonormal1">It happened that, while Apollos was in Corinth, Paul had
 passed through the upper country and arrived in Ephesus. And finding some
@@ -1924,7 +1924,7 @@ these words, he dismissed the assembly.</p>
 
 <p class="sectiontopic">In Greece—Troas –Eutychus falls from a window</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_20">20</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_20">20</p>
 
 <p class="msonormal1">When the uproar had ended, Paul sent for the disciples. He
 then took leave of them and left for Macedonia. <sup class="calibre31">2</sup>As he traveled
@@ -2014,7 +2014,7 @@ to the ship.</p>
 
 <p class="sectiontopic">In Tyre, Ptolemais and Caesarea</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_21">21</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_21">21</p>
 
 <p class="msonormal1">After departing from them, we set sail and made a straight
 course to Cos. The next day, [we sailed] to Rhodes and from there to Patara. <sup class="calibre31">2</sup>Having
@@ -2124,7 +2124,7 @@ language, saying:</p>
 
 <p class="sectiontopic">Paul’s defense</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_22">22</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_22">22</p>
 
 <p class="msonormal1">“Brothers and fathers, listen to the defense which I now
 make to you.”</p>
@@ -2214,7 +2214,7 @@ Sanhedrin to appear. He then brought Paul down and set him before them.</p>
 
 <p class="sectiontopic">Paul before the Sanhedrin</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_23">23</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_23">23</p>
 
 <p class="msonormal1">Looking straight at the Sanhedrin, Paul said, “Brothers, I
 have lived before God in all good conscience until this day.” <sup class="calibre31">2</sup>Then
@@ -2320,7 +2320,7 @@ then commanded that Paul should be held in Herod’s palace.</p>
 
 <p class="sectiontopic">Paul before Felix</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_24">24</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_24">24</p>
 
 <p class="msonormal1">Five days later, the high priest, Ananias, came down with
 the presbyters and a professional speaker<a title="" href="part0000_split_126.html#_edn1530" class="pcalibre pcalibre1" id="_ednref1530"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1530]</span></span></span></a>
@@ -2387,7 +2387,7 @@ Jews, Felix left Paul imprisoned.</p>
 
 <p class="sectiontopic">Paul appeals to Caesar</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_25">25</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_25">25</p>
 
 <p class="msonormal1">Three days after arriving in the province, Festus went up to
 Jerusalem from Caesarea. <sup class="calibre31">2</sup>Then the high priest and the leaders of
@@ -2467,7 +2467,7 @@ prisoner without also specifying the charges against him.”</p>
 
 <p class="msonormal10"> </p>
 
-<p class="style37ptbefore0ptloweredby6ptlinespacingexactl" id="toc_26">26</p>
+<p class="chapter-number chapter-number--nudge-6" id="toc_26">26</p>
 
 <p class="msonormal1">Agrippa said to Paul, “You may speak for yourself.”</p>
 
@@ -2554,7 +2554,7 @@ Festus, “This man might have been set free if he had not appealed to Caesar.�
 
 <p class="sectiontopic">Paul is sent to Rome—Shipwrecked in Malta</p>
 
-<p class="style35ptloweredby1ptlinespacingexactly2445pt" id="toc_27">27</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_27">27</p>
 
 <p class="msonormal1">When it was determined that we should sail for Italy, the
 authorities<a title="" href="part0000_split_126.html#_edn1545" class="pcalibre pcalibre1" id="_ednref1545"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1545]</span></span></span></a>
@@ -2652,7 +2652,7 @@ things from the ship. And so it was that they all escaped safely to the land.</p
 
 <p class="sectiontopic">In Malta—Paul bitten by a snake</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_28">28</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_28">28</p>
 
 <p class="msonormal1">Once safe on the shore, they learned that the island was
 called Malta. <sup class="calibre31">2</sup>The natives showed us unusual kindness; they kindled

--- a/text/part0000_split_037.html
+++ b/text/part0000_split_037.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection8">
+<div class="section">
 <div class="calibre11">
 <p class="heading1b" id="calibre_pb_61"><a class="pcalibre pcalibre1" id="_Toc425418827"></a><a class="pcalibre pcalibre1" id="_Toc425418684"></a><a class="pcalibre pcalibre1" id="_Toc425418536"></a><a class="pcalibre pcalibre1" id="_Toc290636403">INTRODUCTION
 TO<br class="calibre6"/>

--- a/text/part0000_split_038.html
+++ b/text/part0000_split_038.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection8">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_62"><a class="pcalibre pcalibre1" id="_Toc425418828"></a><a class="pcalibre pcalibre1" id="_Toc425418685"></a><a class="pcalibre pcalibre1" id="_Toc425418537">AUTHORSHIP AND DATES</a></h2>
 
 <p class="msonormal1">Orthodox tradition affirms the Pauline authorship of all the

--- a/text/part0000_split_039.html
+++ b/text/part0000_split_039.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection8">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_63"><a class="pcalibre pcalibre1" id="_Toc425418829"></a><a class="pcalibre pcalibre1" id="_Toc425418686"></a><a class="pcalibre pcalibre1" id="_Toc425418538">THEME</a></h2>
 
 <p class="msonormal1">As he addresses a large number of practical issues and

--- a/text/part0000_split_040.html
+++ b/text/part0000_split_040.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection8">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_64"><a class="pcalibre pcalibre1" id="_Toc425418830"></a><a class="pcalibre pcalibre1" id="_Toc425418687"></a><a class="pcalibre pcalibre1" id="_Toc425418539">TRANSLATION NOTE FOR ROMANS</a></h2>
 
 <p class="msonormal1">In this complex theological masterpiece, St. Paul often used

--- a/text/part0000_split_041.html
+++ b/text/part0000_split_041.html
@@ -7,14 +7,14 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection9">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_68"><a class="pcalibre pcalibre1" id="_Toc425418831"></a><a class="pcalibre pcalibre1" id="_Toc425418688"></a><a class="pcalibre pcalibre1" id="_Toc425418540"></a><a class="pcalibre pcalibre1" id="_Toc290636404">Romans  <br class="calibre6"/>
 </a><span class="calibre62">(ΠΡΟΣ
 ΡΩΜΑΙΟΥΣ)</span></h1>
 
 <p class="sectiontopic">Greetings</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">Paul, a bondservant of Jesus Christ, called to be an
 apostle, set apart for the Good News of God, <sup class="calibre31">2</sup>which he promised
@@ -97,7 +97,7 @@ but also approve of those who practice them.</p>
 
 <p class="sectiontopic">The judgment of God</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">Therefore, you are without excuse, if you are judging! For
 in passing judgment on another, you condemn yourself, because you pass judgment
@@ -164,7 +164,7 @@ their praise is not from human beings but from God.</span></p>
 
 <p class="sectiontopic">Objections and answers—The domination of sin</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">And so, what advantage does the Jew have? Or what is the
 benefit of circumcision? <sup class="calibre31">2</sup>Much in every way! First of all, the Jews<a title="" href="part0000_split_126.html#_edn1580" class="pcalibre pcalibre1" id="_ednref1580"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1580]</span></span></span></a>
@@ -249,7 +249,7 @@ the law.</p>
 
 <p class="sectiontopic">About Abraham</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">4</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_4">4</p>
 
 <p class="msonormal1">What then will we say that Abraham (our father according to
 the flesh) gained? <sup class="calibre31">2</sup>Certainly, if Abraham was justified by works, he
@@ -311,7 +311,7 @@ justification.</p>
 
 <p class="sectiontopic">Reconciled with God through Christ</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_5">5</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_5">5</p>
 
 <p class="msonormal1"><span class="calibre71">Being therefore
 justified by faith, we have<a title="" href="part0000_split_126.html#_edn1610" class="pcalibre pcalibre1" id="_ednref1610"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre83">[1610]</span></span></span></a>
@@ -365,7 +365,7 @@ our Lord.</p>
 
 <p class="sectiontopic">United to Christ—Baptism—Dead to sin</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_6">6</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_6">6</p>
 
 <p class="msonormal1"><span class="calibre71">What then shall we say?
 Shall we continue in sin, so that grace may abound? <sup class="calibre31">2</sup>May it never
@@ -413,7 +413,7 @@ gift of God is eternal life in Christ Jesus our Lord.</p>
 
 <p class="sectiontopic">Released from the Law—Its role</p>
 
-<p class="style35ptloweredby1ptlinespacingexactly2445pt" id="toc_7">7</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_7">7</p>
 
 <p class="msonormal1">Do you not know, brethren (for I speak to men who know the
 law), that the law has dominion over a person for as long as that person lives?
@@ -471,7 +471,7 @@ flesh, [I serve] the law of sin.</p>
 
 <p class="sectiontopic">Free from the law of sin and of death </p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_8">8</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_8">8</p>
 
 <p class="msonormal1">Therefore, there is now no condemnation for those who are in
 Christ Jesus, &lt;who do not walk according to the flesh but according to the
@@ -566,7 +566,7 @@ Jesus our Lord.</p>
 
 <p class="sectiontopic">Paul’s sorrow for Israel’s unbelief—God’s sovereign mercy</p>
 
-<p class="style365ptloweredby1ptlinespacingexactly2445pt" id="toc_9">9</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_9">9</p>
 
 <p class="msonormal1">I tell the truth in Christ. I am not lying and my conscience
 bears witness with me in the Holy Spirit <sup class="calibre31">2</sup>that I have great sorrow
@@ -670,7 +670,7 @@ offense;</p>
 
 <p class="sectiontopic">About Israel—On salvation</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_10">10</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_10">10</p>
 
 <p class="msonormal1">Brethren, my heart’s desire and my prayer to God are for
 Israel, that they may be saved. <sup class="calibre31">2</sup>Certainly, I testify about them
@@ -736,7 +736,7 @@ opposing people.<a title="" href="part0000_split_126.html#_edn1678" class="pcali
 
 <p class="sectiontopic">Israel—A remnant—The olive tree</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_11">11</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_11">11</p>
 
 <p class="msonormal1">I ask then, did God reject his people? May it never be! In
 fact, I too am an Israelite, a descendant of Abraham, of the tribe of Benjamin.
@@ -842,7 +842,7 @@ are all things. To him be the glory unto the ages! Amen.</p>
 
 <p class="sectiontopic">Holy worship—One Body, many parts</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_12">12</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_12">12</p>
 
 <p class="msonormal1">Therefore, I urge you, brethren, by the mercies of God, to
 present your bodies as a living sacrifice, holy, acceptable to God, which is
@@ -893,7 +893,7 @@ evil with good.</p>
 
 <p class="sectiontopic">About higher authorities</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_13">13</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_13">13</p>
 
 <p class="msonormal1">Let every human being be in subjection to the higher
 authorities because there is no authority except from God, and those who exist
@@ -937,7 +937,7 @@ think how to satisfy the flesh and its lusts.</p>
 
 <p class="sectiontopic">Mutual respect</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_14">14</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_14">14</p>
 
 <p class="msonormal1">Accept the one who is weak in faith, but not to enter into
 arguments over disputable matters. <sup class="calibre31">2</sup>One has faith to eat all things
@@ -1005,7 +1005,7 @@ forever! Amen.<a title="" href="part0000_split_126.html#_edn1707" class="pcalibr
 
 <p class="sectiontopic">Endurance and encouragement </p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_15">15</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_15">15</p>
 
 <p class="msonormal1">Now we who are strong should bear the weaknesses of the
 weak, and not {just} please ourselves. <sup class="calibre31">2</sup>Let each one of us please
@@ -1100,7 +1100,7 @@ be with you all! Amen.</p>
 
 <p class="sectiontopic">Greetings</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_16">16</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_16">16</p>
 
 <p class="msonormal1">I commend to you Phoebe, our sister, who is a servant<a title="" href="part0000_split_126.html#_edn1718" class="pcalibre pcalibre1" id="_ednref1718"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1718]</span></span></span></a>
 of the Church that is at Cenchreae, <sup class="calibre31">2</sup>so that you receive her in the
@@ -1153,7 +1153,7 @@ Amen.<sup class="calibre31">25<a title="" href="part0000_split_126.html#_edn1725
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection10">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_69"></div>
 </div>

--- a/text/part0000_split_042.html
+++ b/text/part0000_split_042.html
@@ -7,12 +7,12 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection10">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_70"><a class="pcalibre pcalibre1" id="_Toc425418832"></a><a class="pcalibre pcalibre1" id="_Toc425418689"></a><a class="pcalibre pcalibre1" id="_Toc425418541"></a><a class="pcalibre pcalibre1" id="_Toc290636405">1 Corinthians  <br class="calibre6"/>
 </a><span class="calibre62">(ΠΡΟΣ
 ΚΟΡΙΝΘΙΟΥΣ Α)</span></h1>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">Paul, called to be an apostle of Jesus Christ through the
 will of God, and our brother Sosthenes, <sup class="calibre31">2</sup>to the Church of God which
@@ -83,7 +83,7 @@ written, “Whoever boasts should boast in the Lord.”<a title="" href="part000
 
 <p class="sectiontopic">God’s Wisdom—The Spirit of God</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">When I came to you, brethren, I did not come with excellence
 of speech or wisdom, proclaiming to you the testimony<a title="" href="part0000_split_126.html#_edn1731" class="pcalibre pcalibre1" id="_ednref1731"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1731]</span></span></span></a>
@@ -130,7 +130,7 @@ But we have the mind of Christ!</p>
 
 <p class="sectiontopic">God’s co-workers—Spiritual living</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">Brethren, I could not speak to you as to spiritual persons,
 but as to carnal ones—infants in Christ. <sup class="calibre31">2</sup>I fed you with milk and
@@ -176,7 +176,7 @@ God.<a title="" href="part0000_split_126.html#_edn1750" class="pcalibre pcalibre
 
 <p class="sectiontopic">Stewards of God’s mysteries—Paul’s example </p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">4</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_4">4</p>
 
 <p class="msonormal1">And so, let everyone think of us as Christ’s servants and
 stewards<a title="" href="part0000_split_126.html#_edn1751" class="pcalibre pcalibre1" id="_ednref1751"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1751]</span></span></span></a>
@@ -223,7 +223,7 @@ with a spirit of gentleness?</p>
 
 <p class="sectiontopic">A case of sexual immorality</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_5">5</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_5">5</p>
 
 <p class="msonormal1">It is actually reported that there is sexual immorality
 among you, and a kind as does not even occur<a title="" href="part0000_split_126.html#_edn1755" class="pcalibre pcalibre1" id="_ednref1755"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1755]</span></span></span></a>
@@ -260,7 +260,7 @@ those who are within? <sup class="calibre31">13</sup>But those who are outside, 
 
 <p class="sectiontopic">Lawsuits among Christians</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_6">6</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_6">6</p>
 
 <p class="msonormal1">Now how can any of you dare go to court before the
 unrighteous (and not before the saints) when there is a matter against a
@@ -311,7 +311,7 @@ belong to God.<a title="" href="part0000_split_126.html#_edn1767" class="pcalibr
 
 <p class="sectiontopic">About marriage and marital relations</p>
 
-<p class="style35ptloweredby1ptlinespacingexactly2445pt" id="toc_7">7</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_7">7</p>
 
 <p class="msonormal1">Now concerning the matters you wrote to me about: ‘it is
 good for a man not to touch a woman.’ <sup class="calibre31">2</sup>However, to avoid sexual
@@ -411,7 +411,7 @@ God.</p>
 
 <p class="sectiontopic">Concerning things sacrificed to idols </p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_8">8</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_8">8</p>
 
 <p class="msonormal1">Now concerning things sacrificed to idols: we know that we
 all have knowledge. Knowledge makes arrogant, but love builds up. <sup class="calibre31">2</sup>But
@@ -438,7 +438,7 @@ ever eat meat, so that I may not cause my brethren to stumble.</p>
 
 <p class="sectiontopic">Paul’s apostleship—His rights</p>
 
-<p class="style365ptloweredby1ptlinespacingexactly2445pt" id="toc_9">9</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_9">9</p>
 
 <p class="msonormal1">Am I not an apostle? Am I not free? Have I not seen Jesus
 Christ our Lord? Are you not my work in the Lord? <sup class="calibre31">2</sup>If to others I am
@@ -499,7 +499,7 @@ preached to others, I myself should be disqualified.</p>
 
 <p class="sectiontopic">Warnings from the Old Testament</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_10">10</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_10">10</p>
 
 <p class="msonormal1">Now I do not want you to be ignorant, brethren, that our
 forefathers were all under the cloud: all passed through the sea; <sup class="calibre31">2</sup>and
@@ -570,7 +570,7 @@ many, so that they may be saved.</p>
 
 <p class="sectiontopic">Headship—Discipline in the assembly</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_11">11</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_11">11</p>
 
 <p class="msonormal1">Be my imitators, even as I imitate Christ.</p>
 
@@ -641,7 +641,7 @@ might be for judgment. Other matters I will set in order when I come.</p>
 
 <p class="sectiontopic">The works of the Spirit</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_12">12</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_12">12</p>
 
 <p class="msonormal1">Now concerning spiritual [gifts],<a title="" href="part0000_split_126.html#_edn1798" class="pcalibre pcalibre1" id="_ednref1798"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1798]</span></span></span></a>
 brethren, I do not want you to be ignorant. <sup class="calibre31">2</sup>You know that when you
@@ -701,7 +701,7 @@ way.</p>
 
 <p class="sectiontopic">The way of love</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_13">13</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_13">13</p>
 
 <p class="msonormal1">If I speak with the tongues of men and angels, but do not
 have love, I have become a noisy gong or a clanging cymbal. <sup class="calibre31">2</sup>If I
@@ -734,7 +734,7 @@ and love remain: these three, and the greatest of these is love.</span></p>
 <p class="sectiontopic">About tongues and prophecy: personal and communal
 edification</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_14">14</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_14">14</p>
 
 <p class="msonormal1">Pursue love, and eagerly desire spiritual [gifts],<a title="" href="part0000_split_126.html#_edn1803" class="pcalibre pcalibre1" id="_ednref1803"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1803]</span></span></span></a>
 especially that you may prophesy. <sup class="calibre31">2</sup>For whoever speaks in another
@@ -833,7 +833,7 @@ all things be done decently and in order.</p>
 
 <p class="sectiontopic">The Good News and the Resurrection</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_15">15</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_15">15</p>
 
 <p class="msonormal1">Now I declare to you, brethren, the Good News which I
 preached to you, which also you accepted,<a title="" href="part0000_split_126.html#_edn1813" class="pcalibre pcalibre1" id="_ednref1813"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1813]</span></span></span></a>
@@ -950,7 +950,7 @@ your labor in the Lord is not in vain.</span></p>
 
 <p class="sectiontopic">About the collection and Paul’s plans</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_16">16</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_16">16</p>
 
 <p class="msonormal1">Now concerning the collection for the saints, do as I
 instructed the Churches of Galatia. <sup class="calibre31">2</sup>On the first day of the week,
@@ -1002,7 +1002,7 @@ love is with you all in Christ Jesus. Amen.</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection11">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_71"></div>
 </div>

--- a/text/part0000_split_043.html
+++ b/text/part0000_split_043.html
@@ -7,14 +7,14 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection11">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_72"><a class="pcalibre pcalibre1" id="_Toc425418833"></a><a class="pcalibre pcalibre1" id="_Toc425418690"></a><a class="pcalibre pcalibre1" id="_Toc425418542"></a><a class="pcalibre pcalibre1" id="_Toc290636406">2 Corinthians  <br class="calibre6"/>
 </a><span class="calibre62">(ΠΡΟΣ
 ΚΟΡΙΝΘΙΟΥΣ Β)</span></h1>
 
 <p class="sectiontopic">Afflictions and blessings</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">Paul, an apostle of Jesus Christ by the will of God, and
 Timothy our brother, to the Church of God which is at Corinth, with all the
@@ -70,7 +70,7 @@ for your joy, as you stand firm in faith.</p>
 
 <p class="sectiontopic">About the first letter and its effect</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">But I resolved this for myself: that I would not return to
 you in sorrow. <sup class="calibre31">2</sup>If I cause you distress, who will bring me joy
@@ -110,7 +110,7 @@ God and in the sight of God.</p>
 
 <p class="sectiontopic">The ministry of the Spirit </p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">Are we again trying to obtain your approval? Or do we need
 (as some do) letters of recommendation to you or from you? <sup class="calibre31">2</sup>You are
@@ -149,7 +149,7 @@ and this is from the Lord, the Spirit.</p>
 
 <p class="sectiontopic">A difficult ministry</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">4</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_4">4</p>
 
 <p class="msonormal1">Therefore, seeing that we have this ministry, even as we
 have obtained mercy, we do not waver. <sup class="calibre31">2</sup>We have renounced the hidden
@@ -191,7 +191,7 @@ are seen are temporal, but the things which are not seen are eternal.</p>
 
 <p class="sectiontopic">After death</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_5">5</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_5">5</p>
 
 <p class="msonormal1">We know that if our earthly tent<a title="" href="part0000_split_126.html#_edn1849" class="pcalibre pcalibre1" id="_ednref1849"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1849]</span></span></span></a>
 is dissolved, we have a building from God, a house not made with hands, eternal
@@ -245,7 +245,7 @@ for our sake; so that in him, we might become the righteousness of God.</p>
 
 <p class="sectiontopic">Tribulations in the ministry</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_6">6</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_6">6</p>
 
 <p class="msonormal1">Since we are God’s<a title="" href="part0000_split_126.html#_edn1860" class="pcalibre pcalibre1" id="_ednref1860"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1860]</span></span></span></a>
 fellow workers, we also entreat you not to receive his grace in vain, <sup class="calibre31">2</sup>for
@@ -301,7 +301,7 @@ in them; and I will be their God, and they will be my people.”<a title="" href
 
 <p class="msonormal1">says the Lord Almighty.”<a title="" href="part0000_split_126.html#_edn1869" class="pcalibre pcalibre1" id="_ednref1869"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1869]</span></span></span></a></p>
 
-<p class="style375ptbefore0ptloweredby7ptlinespacingexac" id="toc_7">7</p>
+<p class="chapter-number chapter-number--nudge-7" id="toc_7">7</p>
 
 <p class="msonormal1">Since we have these promises, beloved, let us purify
 ourselves from all defilement of flesh and spirit, so that we may bring [our]
@@ -345,7 +345,7 @@ concerning you, I can be confident in everything.</p>
 
 <p class="sectiontopic">About giving</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_8">8</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_8">8</p>
 
 <p class="msonormal1">Moreover, brethren, I want you to know about the grace that
 God has given in the Churches of Macedonia: <sup class="calibre31">2</sup>in spite of extreme
@@ -396,7 +396,7 @@ boast about you to them.</p>
 
 <p class="sectiontopic">The ministry to the saints</p>
 
-<p class="style365ptloweredby1ptlinespacingexactly2445pt" id="toc_9">9</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_9">9</p>
 
 <p class="msonormal1">It is not necessary that I should write to you about the
 ministry to the saints. <sup class="calibre31">2</sup>Indeed, I know that you are ready and I
@@ -437,7 +437,7 @@ unspeakable gift!</span></p>
 
 <p class="sectiontopic">Paul defends his person and ministry</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_10">10</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_10">10</p>
 
 <p class="msonormal1">I, Paul, entreat you by the humility and gentleness of
 Christ, as one who is humble among you in your presence but bold in my absence.
@@ -476,7 +476,7 @@ it is the Lord who gives [him] approval.</p>
 
 <p class="sectiontopic">False apostles </p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_11">11</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_11">11</p>
 
 <p class="msonormal1">I wish that you would be patient with me in a little
 foolishness, and indeed, you are! <sup class="calibre31">2</sup>Certainly, I am jealous over you
@@ -546,7 +546,7 @@ hands.</p>
 
 <p class="sectiontopic">Visions and revelations—A thorn in the flesh</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_12">12</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_12">12</p>
 
 <p class="msonormal1">Without a doubt, it is not profitable for me to boast, but I
 will now discuss visions and revelations from the Lord. <sup class="calibre31">2</sup>I know a
@@ -639,7 +639,7 @@ love of God, and the communion of the Holy Spirit, be with all of you. Amen.</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection12">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_73"></div>
 </div>

--- a/text/part0000_split_044.html
+++ b/text/part0000_split_044.html
@@ -7,12 +7,12 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection12">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_74"><a class="pcalibre pcalibre1" id="_Toc425418834"></a><a class="pcalibre pcalibre1" id="_Toc425418691"></a><a class="pcalibre pcalibre1" id="_Toc425418543"></a><a class="pcalibre pcalibre1" id="_Toc290636407">Galatians  <br class="calibre6"/>
 </a><span class="calibre62">(ΠΡΟΣ
 ΓΑΛΑΤΑΣ)</span></h1>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">Paul, an apostle (sent neither by human commission nor from
 human authorities, but through Jesus Christ and God the Father, who raised him
@@ -62,7 +62,7 @@ Judea which were in Christ; <sup class="calibre31">23</sup>they only heard, “T
 persecuted us is now preaching the faith that he once tried to destroy!” <sup class="calibre31">24</sup>And
 they glorified God in me.</span>                              </p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">Fourteen years later, I went up again to Jerusalem with
 Barnabas, and Titus accompanied me. <sup class="calibre31">2</sup>I went up by revelation and I
@@ -119,7 +119,7 @@ Son of God, who loved me and who gave himself up for me. <sup class="calibre31">
 nullify the grace of God! Truly, if righteousness is through the law, then
 Christ died for nothing!”               </p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">Senseless Galatians! Christ was openly presented before your
 eyes as crucified—who then bewitched you not to obey the truth?<a title="" href="part0000_split_126.html#_edn1899" class="pcalibre pcalibre1" id="_ednref1899"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1899]</span></span></span></a>
@@ -187,7 +187,7 @@ Christ’s, then you are Abraham’s seed and heirs according to the promise.</p
 
 <p class="sectiontopic">Free children</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">4</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_4">4</p>
 
 <p class="msonormal1">Here is my point: as long as the heir is a child, he is no
 different than a slave, although being the owner of everything. <sup class="calibre31">2</sup>The
@@ -268,7 +268,7 @@ bondmaid, but children of the free woman!</p>
 
 <p class="sectiontopic">Freedom in Christ or yoke of slavery</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_5">5</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_5">5</p>
 
 <p class="msonormal1">Therefore, stand firm in the freedom by which Christ has
 made us free, and do not be entangled again with a yoke of slavery! <sup class="calibre31">2</sup>Behold,
@@ -320,7 +320,7 @@ belong to Christ have crucified the flesh with its passions and lusts. <sup clas
 we live by the Spirit, let us also walk by the Spirit! <sup class="calibre31">26</sup>Let us not
 become arrogant, challenging and envying one another.</span>                             </p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_6">6</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_6">6</p>
 
 <p class="msonormal1"><span class="calibre27">Brethren, even if someone
 is caught in some fault, you who are spiritual must restore such a person in a
@@ -365,7 +365,7 @@ your spirit, brethren. Amen.</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection13">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_75"></div>
 </div>

--- a/text/part0000_split_045.html
+++ b/text/part0000_split_045.html
@@ -7,12 +7,12 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection13">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_76"><a class="pcalibre pcalibre1" id="_Toc425418835"></a><a class="pcalibre pcalibre1" id="_Toc425418692"></a><a class="pcalibre pcalibre1" id="_Toc425418544"></a><a class="pcalibre pcalibre1" id="_Toc290636408">Ephesians  <br class="calibre6"/>
 </a><span class="calibre62">(ΠΡΟΣ
 ΕΦΕΣΙΟΥΣ)</span></h1>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">Paul, an apostle of Jesus Christ by the will of God, to the
 saints who are at Ephesus, faithful in Christ Jesus: <sup class="calibre31">2</sup>Grace to you
@@ -65,7 +65,7 @@ who fills all in all.</span></p>
 
 <p class="sectiontopic">The gift of God</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">You were dead in transgressions and sins, <sup class="calibre31">2</sup>and
 this was your lifestyle according to the age<a title="" href="part0000_split_126.html#_edn1933" class="pcalibre pcalibre1" id="_ednref1933"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1933]</span></span></span></a>
@@ -109,7 +109,7 @@ him, you too are built up into a dwelling place of God in [the] Spirit.<a title=
 
 <p class="sectiontopic">Paul’s commission and prayer</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">For this reason, I, Paul, am the prisoner of Christ Jesus on
 behalf of you Gentiles! <sup class="calibre31">2</sup>Surely, you have heard of the dispensation
@@ -152,7 +152,7 @@ Jesus to all generations, unto ages of ages. Amen.</p>
 
 <p class="sectiontopic">Unity and oneness</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">4</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_4">4</p>
 
 <p class="msonormal1">This is why I, being the prisoner in the Lord, beg you to
 walk worthily of the calling with which you were called. <sup class="calibre31">2</sup>[Walk]
@@ -217,7 +217,7 @@ wrath, anger, shouting, and slander be put away from you, along with evil
 thoughts. <sup class="calibre31">32</sup>And be kind to one another, tenderhearted, forgiving
 each other just as God also forgave us in Christ.</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_5">5</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_5">5</p>
 
 <p class="msonormal1">Be imitators of God, as beloved children. <sup class="calibre31">2</sup>Walk
 in love, even as Christ also loved us and gave himself up for us as an offering
@@ -286,7 +286,7 @@ husband.</p>
 
 <p class="sectiontopic">Children and parents</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_6">6</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_6">6</p>
 
 <p class="msonormal1">Children, obey your parents in the Lord, for this is right.</p>
 
@@ -357,7 +357,7 @@ love. Amen.</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection14">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_77"></div>
 </div>

--- a/text/part0000_split_046.html
+++ b/text/part0000_split_046.html
@@ -7,12 +7,12 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection14">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_78"><a class="pcalibre pcalibre1" id="_Toc425418836"></a><a class="pcalibre pcalibre1" id="_Toc425418693"></a><a class="pcalibre pcalibre1" id="_Toc425418545"></a><a class="pcalibre pcalibre1" id="_Toc290636409">Philippians  <br class="calibre6"/>
 </a><span class="calibre62">(ΠΡΟΣ
 ΦΙΛΙΠΠΗΣΙΟΥΣ)</span></h1>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">Paul and Timothy, bondservants of Jesus Christ;</p>
 
@@ -79,7 +79,7 @@ which you saw me fight and that you hear that I am [still] fighting.<a title="" 
 
 <p class="sectiontopic">A call to humility</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">Therefore, if there is any exhortation in Christ, any
 consolation of love, any communion of the Spirit, any tender mercies and compassion,
@@ -143,7 +143,7 @@ me.</p>
 
 <p class="sectiontopic">Warning against evil-workers—Paul’s background</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">Finally, my brethren, rejoice in the Lord! To me, writing
 the same things to you is not tiresome—it is safe! <sup class="calibre31">2</sup>Beware of the
@@ -196,7 +196,7 @@ by which he is able to subject all things to himself.<a title="" href="part0000_
 
 <p class="sectiontopic">Instructions—The peace of God</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">4</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_4">4</p>
 
 <p class="msonormal1">Therefore, my beloved brethren whom I miss so much, my joy
 and my crown, stand firm in the Lord! <sup class="calibre31">2</sup>I exhort Evodia and Syntyche
@@ -249,7 +249,7 @@ Christ be with you all! Amen.</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection15">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_79"></div>
 </div>

--- a/text/part0000_split_047.html
+++ b/text/part0000_split_047.html
@@ -7,12 +7,12 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection15">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_80"><a class="pcalibre pcalibre1" id="_Toc425418837"></a><a class="pcalibre pcalibre1" id="_Toc425418694"></a><a class="pcalibre pcalibre1" id="_Toc425418546"></a><a class="pcalibre pcalibre1" id="_Toc290636410">Colossians  <br class="calibre6"/>
 </a><span class="calibre62">(ΠΡΟΣ
 ΚΟΛOΣΣΑΕΙΣ)</span></h1>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">Paul, an apostle of Jesus Christ through the will of God,
 and Timothy our brother, <sup class="calibre31">2</sup>to the saints and faithful brethren in
@@ -84,7 +84,7 @@ which is powerfully at work in me.</p>
 
 <p class="sectiontopic">Spiritual struggles—Against false teachers</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">I want you to know how greatly I struggle for you, for those
 at Laodicea, and even for all those who do not know me in person. <sup class="calibre31">2</sup>Yes,
@@ -139,7 +139,7 @@ of the flesh.</p>
 
 <p class="sectiontopic">Raised with Christ—Death to what is earthly—The new self</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">If you were raised together with Christ, seek the things
 that are above, where Christ is, seated at the right hand of God! <sup class="calibre31">2</sup>Set
@@ -197,7 +197,7 @@ that you will receive the reward of your inheritance from the Lord, for you
 serve the Lord Christ. <sup class="calibre31">25</sup>But whoever does wrong will receive in
 return according to the wrong that he has done, and there is no partiality.                         </p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt">4</p>
+<p class="chapter-number chapter-number--nudge-2">4</p>
 
 <p class="msonormal1">Masters, give to your slaves what is fair and right, knowing
 that you also have a Master in heaven.</p>
@@ -246,7 +246,7 @@ Remember my chains. Grace be with you! Amen.</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection16">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_81"></div>
 </div>

--- a/text/part0000_split_048.html
+++ b/text/part0000_split_048.html
@@ -7,13 +7,13 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection16">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_82"><a class="pcalibre pcalibre1" id="_Toc425418838"></a><a class="pcalibre pcalibre1" id="_Toc425418695"></a><a class="pcalibre pcalibre1" id="_Toc425418547"></a><a class="pcalibre pcalibre1" id="_Toc290636411">1 Thessalonians  <br class="calibre6"/>
 </a><span class="calibre62">(ΠΡΟΣ
 ΘΕΣΣΑΛΟΝΙΚΕΙΣ
 Α)</span></h1>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">Paul, Silvanus, and Timothy: to the Church of the
 Thessalonians [which is] in God the Father and in the Lord Jesus Christ. Grace
@@ -41,7 +41,7 @@ has raised him from the dead—Jesus, who delivers us from the wrath to come.</p
 
 <p class="sectiontopic">Paul’s relationship with the Thessalonians</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">You certainly know, brethren, that our visit to you was not
 in vain! <sup class="calibre31">2</sup>Having suffered before and having been shamefully treated
@@ -87,7 +87,7 @@ us. <sup class="calibre31">19</sup>For what is our hope, or joy, or crown of rej
 you, when our Lord Jesus Christ<a title="" href="part0000_split_126.html#_edn2020" class="pcalibre pcalibre1" id="_ednref2020"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2020]</span></span></span></a>
 comes? <sup class="calibre31">20</sup>Truly, you are our glory and our joy!                          </p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">Therefore, when we could not stand it any longer, we thought
 that it would be good to be alone in Athens <sup class="calibre31">2</sup>and to send Timothy,
@@ -117,7 +117,7 @@ the end, at the coming of our Lord Jesus with all his saints.</p>
 
 <p class="sectiontopic">Exhortations—Brotherly love</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">4</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_4">4</p>
 
 <p class="msonormal1">As for other matters, brethren, we beg and exhort you in the
 Lord Jesus: as you received from us how you should live to please God, do so
@@ -161,7 +161,7 @@ words.</p>
 
 <p class="sectiontopic">The Lord comes like a thief in the night </p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_5">5</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_5">5</p>
 
 <p class="msonormal1">But concerning the times and seasons, brethren, you have no
 need that anything be written to you. <sup class="calibre31">2</sup>You know well that the day of
@@ -217,7 +217,7 @@ Amen.</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection17">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_83"></div>
 </div>

--- a/text/part0000_split_049.html
+++ b/text/part0000_split_049.html
@@ -7,13 +7,13 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection17">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_84"><a class="pcalibre pcalibre1" id="_Toc425418839"></a><a class="pcalibre pcalibre1" id="_Toc425418696"></a><a class="pcalibre pcalibre1" id="_Toc425418548"></a><a class="pcalibre pcalibre1" id="_Toc290636412">2 Thessalonians  <br class="calibre6"/>
 </a><span class="calibre62">(ΠΡΟΣ
 ΘΕΣΣΑΛΟΝΙΚΕΙΣ
 Β)</span></h1>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">Paul, Silvanus, and Timothy: to the Church of the
 Thessalonians in God our Father, and in the Lord Jesus Christ. <sup class="calibre31">2</sup>Grace
@@ -46,7 +46,7 @@ the Lord Jesus Christ.</p>
 
 <p class="sectiontopic">Apostasy and the man of sin </p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">Now, brethren, concerning the coming of our Lord Jesus
 Christ and our gathering to him,<a title="" href="part0000_split_126.html#_edn2033" class="pcalibre pcalibre1" id="_ednref2033"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2033]</span></span></span></a>
@@ -88,7 +88,7 @@ and work.</p>
 
 <p class="sectiontopic">Request for prayers—Against those who refuse to work</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">As for other matters, brethren, pray for us, so that the
 word of the Lord may spread rapidly and be glorified, just as it is with you. <sup class="calibre31">2</sup>Pray
@@ -130,7 +130,7 @@ the grace of our Lord Jesus Christ be with you all! Amen.</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection18">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_85"></div>
 </div>

--- a/text/part0000_split_050.html
+++ b/text/part0000_split_050.html
@@ -7,12 +7,12 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection18">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_86"><a class="pcalibre pcalibre1" id="_Toc425418840"></a><a class="pcalibre pcalibre1" id="_Toc425418697"></a><a class="pcalibre pcalibre1" id="_Toc425418549"></a><a class="pcalibre pcalibre1" id="_Toc290636413">1 Timothy  <br class="calibre6"/>
 </a><span class="calibre62">(ΠΡΟΣ
 ΤΙΜΟΘΕΟΝ Α)</span></h1>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">Paul, an apostle of Jesus Christ according to the
 commandment of God our Savior, and the Lord Jesus Christ, our hope; <sup class="calibre31">2</sup>to
@@ -74,7 +74,7 @@ so that they might learn not to blaspheme.</p>
 
 <p class="sectiontopic">A call to prayer</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">Therefore, I encourage that first of all, petitions,
 prayers, intercessions and thanksgivings be made for all: <sup class="calibre31">2</sup>for kings
@@ -104,7 +104,7 @@ self-restraint.<a title="" href="part0000_split_126.html#_edn2059" class="pcalib
 
 <p class="sectiontopic">Offices in the Church</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">This is a sure word: if a man aspires to the office of
 overseer<a title="" href="part0000_split_126.html#_edn2060" class="pcalibre pcalibre1" id="_ednref2060"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2060]</span></span></span></a>,
@@ -156,7 +156,7 @@ was revealed in the flesh,</p>
 
 <p class="sectiontopic">Doctrines of demons—False asceticism</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">4</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_4">4</p>
 
 <p class="msonormal1">The Spirit clearly says that in the last times, some will
 fall away from the faith, paying attention to seducing spirits and doctrines of
@@ -194,7 +194,7 @@ and those who hear you.</p>
 
 <p class="sectiontopic">Relationships in the Church—About widows</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_5">5</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_5">5</p>
 
 <p class="msonormal1">Do not [sharply] rebuke an older man, but exhort him as a
 father; the younger men as brothers; <sup class="calibre31">2</sup>older women as mothers; the
@@ -251,7 +251,7 @@ good works are obvious, and even those that are not cannot remain hidden.</p>
 
 <p class="sectiontopic">Rules for slaves</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_6">6</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_6">6</p>
 
 <p class="msonormal1">Those who are under the yoke of slavery should consider
 their masters worthy of all honor, so that God’s Name and our doctrine<a title="" href="part0000_split_126.html#_edn2076" class="pcalibre pcalibre1" id="_ednref2076"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2076]</span></span></span></a>
@@ -315,7 +315,7 @@ have wandered from the faith! Grace be with you! Amen.</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection19">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_87"></div>
 </div>

--- a/text/part0000_split_051.html
+++ b/text/part0000_split_051.html
@@ -7,12 +7,12 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection19">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_88"><a class="pcalibre pcalibre1" id="_Toc425418841"></a><a class="pcalibre pcalibre1" id="_Toc425418698"></a><a class="pcalibre pcalibre1" id="_Toc425418550"></a><a class="pcalibre pcalibre1" id="_Toc290636414">2 Timothy  <br class="calibre6"/>
 </a><span class="calibre62">(ΠΡΟΣ
 ΤΙΜΟΘΕΟΝ B)</span></h1>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">Paul, an apostle of Christ Jesus through the will of God,
 according to the promise of the life which is in Christ Jesus; <sup class="calibre31">2</sup>to
@@ -60,7 +60,7 @@ well.</p>
 
 <p class="sectiontopic">Timothy’s tribulations and commission</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">You, my child, be strengthened in the grace that is in
 Christ Jesus. <sup class="calibre31">2</sup>What you heard from me among many witnesses, entrust
@@ -122,7 +122,7 @@ do his will).</p>
 
 <p class="sectiontopic">Troubled times in the last days, </p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">But know that in the last days, troubled times will come. <sup class="calibre31">2</sup>People
 will be lovers of self, lovers of money, boastful, arrogant, blasphemers,
@@ -161,7 +161,7 @@ for every good work.</p>
 
 <p class="sectiontopic">A charge to preach the word</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">4</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_4">4</p>
 
 <p class="msonormal1">I charge you therefore, before God and the Lord Jesus
 Christ, who will judge the living and the dead at his appearing and his
@@ -214,7 +214,7 @@ the Lord Jesus Christ be with your spirit! Grace be with you. Amen.</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection20">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_89"></div>
 </div>

--- a/text/part0000_split_052.html
+++ b/text/part0000_split_052.html
@@ -7,11 +7,11 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection20">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_90"><a class="pcalibre pcalibre1" id="_Toc425418842"></a><a class="pcalibre pcalibre1" id="_Toc425418699"></a><a class="pcalibre pcalibre1" id="_Toc425418551"></a><a class="pcalibre pcalibre1" id="_Toc290636415">Titus  <br class="calibre6"/>
 </a><span class="calibre62">(ΠΡΟΣ ΤΙΤΟΝ)</span></h1>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">Paul, a bondservant of God and an apostle of Jesus Christ [appointed]
 to bring God’s elect to faith and to the knowledge of the truth which leads to
@@ -53,7 +53,7 @@ work.</p>
 
 <p class="sectiontopic">What Titus should teach</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">Proclaim what is consistent with sound doctrine: <sup class="calibre31">2</sup>that
 older men should be temperate, sensible, sober-minded, sound in faith, love and
@@ -80,7 +80,7 @@ all iniquity and to purify for himself a people for his own possession, zealous
 for good works. <sup class="calibre31">15</sup>Teach these things, exhort and reprove with
 complete authority. Let no one despise you!                              </p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">Remind the people to be submissive to rulers and authorities,
 to be obedient and ready for every good work, <sup class="calibre31">2</sup>not speaking evil of
@@ -120,7 +120,7 @@ love us in faith. Grace be with you all! Amen.</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection21">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_91"></div>
 </div>

--- a/text/part0000_split_053.html
+++ b/text/part0000_split_053.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection21">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_92"><a class="pcalibre pcalibre1" id="_Toc425418843"></a><a class="pcalibre pcalibre1" id="_Toc425418700"></a><a class="pcalibre pcalibre1" id="_Toc425418552"></a><a class="pcalibre pcalibre1" id="_Toc290636416">Philemon  <br class="calibre6"/>
 </a><span class="calibre62">(ΠΡΟΣ
 ΦΙΛΗΜΟΝΑ)</span></h1>
@@ -65,7 +65,7 @@ spirit! Amen.</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection22">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_93"></div>
 </div>

--- a/text/part0000_split_054.html
+++ b/text/part0000_split_054.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection22">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_94"><a class="pcalibre pcalibre1" id="_Toc425418844"></a><a class="pcalibre pcalibre1" id="_Toc425418701"></a><a class="pcalibre pcalibre1" id="_Toc425418553"></a><a class="pcalibre pcalibre1" id="_Toc290636417">Hebrews  <br class="calibre6"/>
 </a><span class="calibre62">(ΠΡΟΣ
 ΕΒΡΑΙΟΥΣ)</span></h1>
@@ -15,7 +15,7 @@
 <p class="sectiontopic">God has spoken through his Son—The Son greater than the
 angels</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">In the past, God spoke to the fathers through the prophets
 at many times and in various ways. <sup class="calibre31">2</sup>At the end of these days, he has
@@ -102,7 +102,7 @@ inherit salvation?</p>
 
 <p class="sectiontopic">Warning not to neglect salvation</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">Therefore, we should pay greater attention to the things
 that we were taught, for fear that we may drift away. <sup class="calibre31">2</sup>Certainly, if
@@ -175,7 +175,7 @@ tempted.</p>
 
 <p class="sectiontopic">A High Priest greater than Moses</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">Therefore, holy brethren, partakers of a heavenly calling,
 consider the Apostle and High Priest of our confession, Jesus Christ, <sup class="calibre31">2</sup>who
@@ -233,7 +233,7 @@ see that they were not able to enter in because of [their] lack of faith.<a titl
 
 <p class="sectiontopic">God’s Sabbath rest</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">4</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_4">4</p>
 
 <p class="msonormal1">Let us beware, then! Since the promise remains, let us be
 careful that none of you be found to have fallen short of it. <sup class="calibre31">2</sup>For
@@ -289,7 +289,7 @@ in time of need.</span></p>
 
 <p class="sectiontopic">A high priest after the order of Melchizedek </p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_5">5</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_5">5</p>
 
 <p class="msonormal1"><span class="calibre27">Every high priest is
 selected from among men and is appointed for their sake in matters pertaining
@@ -330,7 +330,7 @@ experienced in the word of righteousness; such a person is a baby. <sup class="c
 solid food is for those who are fully grown, who have trained their senses to
 discern good and evil.                         </p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_6">6</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_6">6</p>
 
 <p class="msonormal1">Therefore, going beyond the teaching of the basic principles
 about Christ, let us move on to perfection! Let us not lay again a foundation
@@ -375,7 +375,7 @@ after the order of Melchizedek.</p>
 
 <p class="sectiontopic">Melchizedek, Abraham, and Christ</p>
 
-<p class="style35ptloweredby1ptlinespacingexactly2445pt" id="toc_7">7</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_7">7</p>
 
 <p class="msonormal1">This Melchizedek was king of Salem, priest of God Most High,
 who met Abraham when he was returning from the slaughter of the kings and who
@@ -445,7 +445,7 @@ law appoints forever a Son who has been perfected.</p>
 
 <p class="sectiontopic">Christ: high priest and mediator of a better covenant </p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_8">8</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_8">8</p>
 
 <p class="msonormal1">The point of what we are saying is this: we have such a high
 priest, who sat down at the right hand of the throne of the Majesty on high, <sup class="calibre31">2</sup>a
@@ -523,7 +523,7 @@ disappear.</p>
 
 <p class="sectiontopic">The first tabernacle</p>
 
-<p class="style365ptloweredby1ptlinespacingexactly2445pt" id="toc_9">9</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_9">9</p>
 
 <p class="msonormal1">Even the first tabernacle<a title="" href="part0000_split_127.html#_edn2184" class="pcalibre pcalibre1" id="_ednref2184"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2184]</span></span></span></a>
 and covenant had ordinances of divine service<a title="" href="part0000_split_127.html#_edn2185" class="pcalibre pcalibre1" id="_ednref2185"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2185]</span></span></span></a>
@@ -594,7 +594,7 @@ waiting for him for salvation.<a title="" href="part0000_split_127.html#_edn2194
 
 <p class="sectiontopic">One sacrifice for sins </p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_10">10</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_10">10</p>
 
 <p class="msonormal1">The law had a shadow of the good [things] to come but not
 the very image of their reality; for this reason, it can never make perfect
@@ -698,7 +698,7 @@ destruction, but of those who believe and so are saved.</p>
 
 <p class="sectiontopic">By faith</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_11">11</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_11">11</p>
 
 <p class="msonormal1">Now faith is the personal foundation<a title="" href="part0000_split_127.html#_edn2203" class="pcalibre pcalibre1" id="_ednref2203"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2203]</span></span></span></a>
 of things hoped for, certainty about things that cannot be seen. <sup class="calibre31">2</sup>By
@@ -793,7 +793,7 @@ better, and they were not to reach perfection apart from us.</p>
 
 <p class="sectiontopic">God as our Father</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_12">12</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_12">12</p>
 
 <p class="msonormal1">And so, seeing that we are surrounded by such a great a
 cloud of witnesses, let us lay aside every weight and the sin which so easily
@@ -875,7 +875,7 @@ to God acceptably, with reverence and godly fear,<a title="" href="part0000_spli
 
 <p class="sectiontopic">Final exhortations</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt">13</p>
+<p class="chapter-number chapter-number--nudge-1-5">13</p>
 
 <p class="msonormal1">Continue loving each other as brethren. <sup class="calibre31">2</sup>Do not
 forget to be hospitable to strangers, for in doing so, some have welcomed
@@ -949,7 +949,7 @@ Italy greet you. <sup class="calibre31">25</sup>Grace be with you all! Amen.</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection23">
+<div class="section">
 
 <div class="calibre11">
 

--- a/text/part0000_split_055.html
+++ b/text/part0000_split_055.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection23">
+<div class="section">
 <div class="calibre11">
 <p class="heading1b" id="calibre_pb_96"><a class="pcalibre pcalibre1" id="_Toc425418845"></a><a class="pcalibre pcalibre1" id="_Toc425418702"></a><a class="pcalibre pcalibre1" id="_Toc425418554"></a><a class="pcalibre pcalibre1" id="_Toc290636418">INTRODUCTION
 TO<br class="calibre6"/>

--- a/text/part0000_split_056.html
+++ b/text/part0000_split_056.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection23">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_97"><a class="pcalibre pcalibre1" id="_Toc425418846"></a><a class="pcalibre pcalibre1" id="_Toc425418703"></a><a class="pcalibre pcalibre1" id="_Toc425418555">THE EPISTLE OF JAMES</a></h2>
 
 <p class="msonormal1"><b class="calibre7">Authorship/Date</b></p>

--- a/text/part0000_split_057.html
+++ b/text/part0000_split_057.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection23">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_98"><a class="pcalibre pcalibre1" id="_Toc425418847"></a><a class="pcalibre pcalibre1" id="_Toc425418704"></a><a class="pcalibre pcalibre1" id="_Toc425418556">THE EPISTLES OF JOHN</a></h2>
 
 <p class="msonormal1"><b class="calibre7">Authorship/Dates</b></p>

--- a/text/part0000_split_058.html
+++ b/text/part0000_split_058.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection23">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_99"><a class="pcalibre pcalibre1" id="_Toc425418848"></a><a class="pcalibre pcalibre1" id="_Toc425418705"></a><a class="pcalibre pcalibre1" id="_Toc425418557">THE PETRINE EPISTLES, THE EPISTLE OF JUDE</a></h2>
 
 <p class="msonormal1"><b class="calibre7">Authorship/Dates</b></p>
@@ -99,7 +99,7 @@ apostasy as a rebellion against divinely established order.</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection24">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_100"></div>
 </div>

--- a/text/part0000_split_059.html
+++ b/text/part0000_split_059.html
@@ -7,12 +7,12 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection24">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_101"><a class="pcalibre pcalibre1" id="_Toc425418849"></a><a class="pcalibre pcalibre1" id="_Toc425418706"></a><a class="pcalibre pcalibre1" id="_Toc425418558"></a><a class="pcalibre pcalibre1" id="_Toc290636419"><span id="KB7-53f1c2fa46e747eea0a124c9756c4a6f" class="calibre25">JAMES</span>  <br class="calibre6"/>
 </a><span class="calibre62">(ΕΠΙΣΤΟΛΗ
 ΙΑΚΩΒΟΥ)</span></h1>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">James, a bondservant of God and of the Lord Jesus Christ, to
 the Twelve tribes which are in the Dispersion: Greetings!</p>
@@ -74,7 +74,7 @@ and to keep oneself unstained by the world.</p>
 
 <p class="sectiontopic">Partiality and judgment</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">My brethren, do not hold the faith of our Lord of glory
 Jesus Christ with partiality.<a title="" href="part0000_split_127.html#_edn2248" class="pcalibre pcalibre1" id="_ednref2248"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2248]</span></span></span></a>
@@ -131,7 +131,7 @@ so is faith dead apart from works.</p>
 
 <p class="sectiontopic">The tongue as fire</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">Not many of you should be teachers, my brethren, knowing
 that we shall receive a stricter judgment. <sup class="calibre31">2</sup>In many things, we all
@@ -169,7 +169,7 @@ righteousness is sown in peace by those who make peace.<a title="" href="part000
 
 <p class="sectiontopic">Cause of conflicts</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">4</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_4">4</p>
 
 <p class="msonormal1">These wars and conflicts among you, where do they come from?
 Is it not from your desires that wage war in your members? <sup class="calibre31">2</sup>You
@@ -212,7 +212,7 @@ how to do what is good and yet does not do it, it is a sin.</p>
 
 <p class="sectiontopic">Warning to the wealthy</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_5">5</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_5">5</p>
 
 <p class="msonormal1">Listen, you who are rich: weep and howl for the miseries
 that are coming on you. <sup class="calibre31">2</sup>Your riches are corrupted and your garments
@@ -268,7 +268,7 @@ multitude of sins.<a title="" href="part0000_split_127.html#_edn2280" class="pca
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection25">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_102"></div>
 </div>

--- a/text/part0000_split_060.html
+++ b/text/part0000_split_060.html
@@ -7,12 +7,12 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection25">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_103"><a class="pcalibre pcalibre1" id="_Toc425418850"></a><a class="pcalibre pcalibre1" id="_Toc425418707"></a><a class="pcalibre pcalibre1" id="_Toc425418559"></a><a class="pcalibre pcalibre1" id="_Toc290636420">1 Peter  <br class="calibre6"/>
 </a><span class="calibre62">(ΕΠΙΣΤΟΛΗ
 ΠΕΤΡΟΥ Α)</span></h1>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">Peter, an apostle of Jesus Christ, to the elect<a title="" href="part0000_split_127.html#_edn2281" class="pcalibre pcalibre1" id="_ednref2281"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2281]</span></span></span></a>
 who are living as exiles, scattered<a title="" href="part0000_split_127.html#_edn2282" class="pcalibre pcalibre1" id="_ednref2282"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2282]</span></span></span></a>
@@ -89,7 +89,7 @@ which lives and remains forever.<a title="" href="part0000_split_127.html#_edn22
 
 <p class="sectiontopic">A spiritual house, a holy priesthood</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">Therefore, putting away all wickedness, deceit, hypocrisies,
 envies, and all evil speaking, <sup class="calibre31">2</sup>as newborn babies, long for the pure
@@ -159,7 +159,7 @@ of your souls.</p>
 
 <p class="sectiontopic">Instructions for wives and husbands</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt">3</p>
+<p class="chapter-number chapter-number--nudge-1-5">3</p>
 
 <p class="msonormal1" id="toc_3"><span class="calibre91">In the same way, wives, be
 in subjection to your own husbands. This way, even if they do not obey the
@@ -233,7 +233,7 @@ with angels, authorities, and powers being subject to him.</p>
 
 <p class="sectiontopic">Life in the spirit</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt">4</p>
+<p class="chapter-number chapter-number--nudge-2">4</p>
 
 <p class="msonormal1">Therefore, as Christ suffered for us in the flesh, equip
 yourselves with the same mind; for anyone who has suffered in the flesh has
@@ -291,7 +291,7 @@ to him as to a faithful Creator.</p>
 
 <p class="sectiontopic">Exhortation to presbyters </p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt">5</p>
+<p class="chapter-number chapter-number--nudge-1-5">5</p>
 
 <p class="msonormal1"><span class="calibre27">I exhort the presbyters among
 you, as the fellow presbyter<a title="" href="part0000_split_127.html#_edn2329" class="pcalibre pcalibre1" id="_ednref2329"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre30">[2329]</span></span></span></a>

--- a/text/part0000_split_061.html
+++ b/text/part0000_split_061.html
@@ -7,12 +7,12 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection26">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_107"><a class="pcalibre pcalibre1" id="_Toc425418851"></a><a class="pcalibre pcalibre1" id="_Toc425418708"></a><a class="pcalibre pcalibre1" id="_Toc425418560"></a><a class="pcalibre pcalibre1" id="_Toc290636421">2 Peter  <br class="calibre6"/>
 </a><span class="calibre62">(ΕΠΙΣΤΟΛΗ
 ΠΕΤΡΟΥ B)</span></h1>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1">Simeon<a title="" href="part0000_split_127.html#_edn2334" class="pcalibre pcalibre1" id="_ednref2334"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2334]</span></span></span></a>
 Peter, a bondservant and apostle of Jesus Christ, to those who have obtained a
@@ -69,7 +69,7 @@ Holy Spirit.</p>
 
 <p class="sectiontopic">False teachers—Slaves of corruption</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">However, false prophets also arose among the people, as
 false teachers will also be among you. They will secretly bring in destructive
@@ -129,7 +129,7 @@ and “the swine that had been washed [has returned] to wallowing in the mire.�
 
 <p class="sectiontopic">The Lord is not slow </p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">This is now, beloved, the second letter that I have written
 to you and in both of them, I stir up your sincere mind by reminding you <sup class="calibre31">2</sup>that
@@ -184,7 +184,7 @@ Savior Jesus Christ. To him be the glory, both now and unto ages of ages. Amen.<
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection27">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_108"></div>
 </div>

--- a/text/part0000_split_062.html
+++ b/text/part0000_split_062.html
@@ -7,14 +7,14 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection27">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_109"><a class="pcalibre pcalibre1" id="_Toc425418852"></a><a class="pcalibre pcalibre1" id="_Toc425418709"></a><a class="pcalibre pcalibre1" id="_Toc425418561"></a><a class="pcalibre pcalibre1" id="_Toc290636422">1 John  <br class="calibre6"/>
 </a><span class="calibre62">(ΕΠΙΣΤΟΛΗ
 ΙΩΑΝΝΟΥ Α)</span></h1>
 
 <p class="sectiontopic">The Word of life </p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1"><span class="calibre91">What was from the
 beginning, what we have heard, what we have seen with our eyes, what we looked
@@ -44,7 +44,7 @@ our sins, he is faithful and righteous so that he will forgive us our sins and
 cleanse us from all unrighteousness. <sup class="calibre31">10</sup>If we say that we have not
 sinned, we make him a liar and his word is not in us.</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1">My little children, I write these things to you so that you
 may not commit sin. But if someone does commit a sin, we have an advocate<a title="" href="part0000_split_127.html#_edn2355" class="pcalibre pcalibre1" id="_ednref2355"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2355]</span></span></span></a>
@@ -131,7 +131,7 @@ practices righteousness is born of him.</p>
 
 <p class="sectiontopic">God’s children—We will be like him</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1">Behold, how great a love the Father has bestowed upon us,
 that we should be called God’s children!<a title="" href="part0000_split_127.html#_edn2368" class="pcalibre pcalibre1" id="_ednref2368"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2368]</span></span></span></a>
@@ -191,7 +191,7 @@ Spirit that he has given us.</p>
 
 <p class="sectiontopic">Spiritual discernment</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">4</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_4">4</p>
 
 <p class="msonormal1">Beloved, do not believe every spirit, but test the spirits
 to determine whether they are from God, because many false prophets have gone
@@ -240,7 +240,7 @@ from him: that the one who loves God should also love his brethren.</span></p>
 
 <p class="sectiontopic">The victory that has overcome the world </p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_5">5</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_5">5</p>
 
 <p class="msonormal1"><span class="calibre27">Whoever believes that
 Jesus is the Christ is born of God, and whoever loves the Father also loves the
@@ -298,7 +298,7 @@ Amen.</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection28">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_110"></div>
 </div>

--- a/text/part0000_split_063.html
+++ b/text/part0000_split_063.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection28">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_111"><a class="pcalibre pcalibre1" id="_Toc425418853"></a><a class="pcalibre pcalibre1" id="_Toc425418710"></a><a class="pcalibre pcalibre1" id="_Toc425418562"></a><a class="pcalibre pcalibre1" id="_Toc290636423">2 John  <br class="calibre6"/>
 </a><span class="calibre62">(ΕΠΙΣΤΟΛΗ
 ΙΩΑΝΝΟΥ b)</span></h1>
@@ -48,7 +48,7 @@ of your chosen sister greet you. Amen.</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection29">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_112"></div>
 </div>

--- a/text/part0000_split_064.html
+++ b/text/part0000_split_064.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection29">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_113"><a class="pcalibre pcalibre1" id="_Toc425418854"></a><a class="pcalibre pcalibre1" id="_Toc425418711"></a><a class="pcalibre pcalibre1" id="_Toc425418563"></a><a class="pcalibre pcalibre1" id="_Toc290636424">3 John  <br class="calibre6"/>
 </a><span class="calibre62">(ΕΠΙΣΤΟΛΗ ΙΩΑΝΝΟΥ
 Γ)</span></h1>
@@ -50,7 +50,7 @@ you. Greet the friends by name.</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection30">
+<div class="section">
 
 <div class="calibre12" id="calibre_pb_114"></div>
 </div>

--- a/text/part0000_split_065.html
+++ b/text/part0000_split_065.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection30">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_115"><a class="pcalibre pcalibre1" id="_Toc425418855"></a><a class="pcalibre pcalibre1" id="_Toc425418712"></a><a class="pcalibre pcalibre1" id="_Toc425418564"></a><a class="pcalibre pcalibre1" id="_Toc290636425">Jude  <br class="calibre6"/>
 </a><span class="calibre62">(ΕΠΙΣΤΟΛΗ
 ΙΟΥΔΑ)</span></h1>

--- a/text/part0000_split_066.html
+++ b/text/part0000_split_066.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection31">
+<div class="section">
 <div class="calibre11">
 <p class="heading1b" id="calibre_pb_121"><a class="pcalibre pcalibre1" id="_Toc425418856"></a><a class="pcalibre pcalibre1" id="_Toc425418713"></a><a class="pcalibre pcalibre1" id="_Toc425418565"></a><a class="pcalibre pcalibre1" id="_Toc290636426">INTRODUCTION
 TO<br class="calibre6"/>

--- a/text/part0000_split_067.html
+++ b/text/part0000_split_067.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection31">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_122"><a class="pcalibre pcalibre1" id="_Toc425418857"></a><a class="pcalibre pcalibre1" id="_Toc425418714"></a><a class="pcalibre pcalibre1" id="_Toc425418566">AUTHORSHIP AND DATE</a></h2>
 
 <p class="msonormal1">Unlike the Gospel, the book of Revelation or Apocalypse

--- a/text/part0000_split_068.html
+++ b/text/part0000_split_068.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection31">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_123"><a class="pcalibre pcalibre1" id="_Toc425418858"></a><a class="pcalibre pcalibre1" id="_Toc425418715"></a><a class="pcalibre pcalibre1" id="_Toc425418567">FURTHER DISCUSSION OF REVELATION’S DATE</a><a title="" href="part0000_split_127.html#_edn2408" class="pcalibre pcalibre1" id="_ednref2408"><span class="msoendnotereference"><span class="msoendnotereference"><b class="calibre7"><span class="calibre34"><span class="calibre60">[2408]</span></span></b></span></span></a></h2>
 
 <p class="msonormal1">Based on some statements by early writers such as Irenaeus,

--- a/text/part0000_split_069.html
+++ b/text/part0000_split_069.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection31">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_124"><a class="pcalibre pcalibre1" id="_Toc425418859"></a><a class="pcalibre pcalibre1" id="_Toc425418716"></a><a class="pcalibre pcalibre1" id="_Toc425418568">THEME(S)</a></h2>
 
 <p class="msonormal1"><span class="calibre91">Revelation is a fitting

--- a/text/part0000_split_070.html
+++ b/text/part0000_split_070.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection31">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_125"><a class="pcalibre pcalibre1" id="_Toc425418860"></a><a class="pcalibre pcalibre1" id="_Toc425418717"></a><a class="pcalibre pcalibre1" id="_Toc425418569">BABYLON THE GREAT</a></h2>
 
 <p class="msonormal1">Unlike most annotated versions, the EOB footnotes lean

--- a/text/part0000_split_071.html
+++ b/text/part0000_split_071.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection31">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_126"><a class="pcalibre pcalibre1" id="_Toc425418861"></a><a class="pcalibre pcalibre1" id="_Toc425418718"></a><a class="pcalibre pcalibre1" id="_Toc425418570">SIGNS BEFORE 70 AD</a></h2>
 
 <p class="msonormal1">If it is the destruction of Jerusalem that is envisioned in

--- a/text/part0000_split_072.html
+++ b/text/part0000_split_072.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection31">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_127"><a class="pcalibre pcalibre1" id="_Toc425418862"></a><a class="pcalibre pcalibre1" id="_Toc425418719"></a><a class="pcalibre pcalibre1" id="_Toc425418571">MYSTICAL PATTERNS</a></h2>
 
 <p class="msonormal1">In Revelation as in the Gospel of John, the patterns of the
@@ -54,7 +54,7 @@ with me, to give to every one according to his work (18:19).</p>
 <span class="calibre5"><br clear="all" class="calibre10"/>
 </span>
 
-<div class="wordsection32">
+<div class="section">
 
 <p class="msonormal1"> </p>
 

--- a/text/part0000_split_073.html
+++ b/text/part0000_split_073.html
@@ -7,12 +7,12 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection32">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_129"><a class="pcalibre pcalibre1" id="_Toc425418863"></a><a class="pcalibre pcalibre1" id="_Toc425418720"></a><a class="pcalibre pcalibre1" id="_Toc425418572"></a><a class="pcalibre pcalibre1" id="_Toc290636427"><span id="LPI-53f1c2fa46e747eea0a124c9756c4a6f" class="calibre25">REVELATION</span>  <br class="calibre6"/>
 </a><span class="calibre62">(ΙΩΑΝΝΟΥ
 ΑΠΟΚΑΛΥΨΙΣ)</span></h1>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_1">1</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_1">1</p>
 
 <p class="msonormal1"><span class="calibre67">This is the Revelation of
 Jesus Christ, which God gave him to show to his bondservants the things which
@@ -41,7 +41,7 @@ Amen.</p>
 eye will see him, including those who pierced him. All the tribes of the earth
 will mourn over him. It shall be so! Amen!</p>
 
-<p class="msonormal1"><sup class="calibre31">8</sup>“I am the Alpha and the Omega<a title="" href="part0000_split_127.html#_edn2427" class="pcalibre pcalibre1" id="_ednref2427"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2427]</span></span></span></a>,<a title="" href="part0000_split_127.html#_edn2428" class="pcalibre pcalibre1" id="_ednref2428"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[2428]</span></span></span></a>”<span class="stylefootnotereferencelatinitalicblack"> </span>says the Lord God,<a title="" href="part0000_split_127.html#_edn2429" class="pcalibre pcalibre1" id="_ednref2429"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2429]</span></span></span></a>
+<p class="msonormal1"><sup class="calibre31">8</sup>“I am the Alpha and the Omega<a title="" href="part0000_split_127.html#_edn2427" class="pcalibre pcalibre1" id="_ednref2427"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2427]</span></span></span></a>,<a title="" href="part0000_split_127.html#_edn2428" class="pcalibre pcalibre1" id="_ednref2428"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[2428]</span></span></span></a>”<span class="footnote-ref"> </span>says the Lord God,<a title="" href="part0000_split_127.html#_edn2429" class="pcalibre pcalibre1" id="_ednref2429"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2429]</span></span></span></a>
 “who is and who was and who is to come, the Almighty.”<a title="" href="part0000_split_127.html#_edn2430" class="pcalibre pcalibre1" id="_ednref2430"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2430]</span></span></span></a></p>
 
 <p class="sectiontopic">In the Spirit on the Lord’s day—The vision of the son of
@@ -52,8 +52,8 @@ oppression, and [in the] Kingdom, and [in] perseverance in Christ Jesus,<a title
 was on the island called Patmos because of the word of God and the testimony of
 Jesus Christ.<a title="" href="part0000_split_127.html#_edn2432" class="pcalibre pcalibre1" id="_ednref2432"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2432]</span></span></span></a>
 <sup class="calibre31">10</sup>I was in the Spirit on the Lord’s day<a title="" href="part0000_split_127.html#_edn2433" class="pcalibre pcalibre1" id="_ednref2433"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2433]</span></span></span></a>
-and I heard behind me a loud voice, like a trumpet <sup class="calibre31">11</sup>saying, “<a title="" href="part0000_split_127.html#_edn2434" class="pcalibre pcalibre1" id="_ednref2434"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[2434]</span></span></span></a>What
-you see, write [it] in a book and send [it] to the seven Churches;<a title="" href="part0000_split_127.html#_edn2435" class="pcalibre pcalibre1" id="_ednref2435"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[2435]</span></span></span></a>
+and I heard behind me a loud voice, like a trumpet <sup class="calibre31">11</sup>saying, “<a title="" href="part0000_split_127.html#_edn2434" class="pcalibre pcalibre1" id="_ednref2434"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[2434]</span></span></span></a>What
+you see, write [it] in a book and send [it] to the seven Churches;<a title="" href="part0000_split_127.html#_edn2435" class="pcalibre pcalibre1" id="_ednref2435"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[2435]</span></span></span></a>
 to Ephesus, Smyrna, Pergamum, Thyatira, Sardis, Philadelphia, and to Laodicea.”</p>
 
 <p class="msonormal1"><sup class="calibre31"><span class="calibre70">12</span></sup><span class="calibre70">I turned around to see the voice that had spoken
@@ -75,12 +75,12 @@ I have the keys of death and of hades. <sup class="calibre31">19</sup>Therefore,
 which you have seen, the things which are now, and the things which will happen
 in the future. <sup class="calibre31">20</sup>Write about the mystery of the seven stars which
 you saw in my right hand, and the seven golden lampstands. The seven stars are
-the angels<a title="" href="part0000_split_127.html#_edn2441" class="pcalibre pcalibre1" id="_ednref2441"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[2441]</span></span></span></a>
+the angels<a title="" href="part0000_split_127.html#_edn2441" class="pcalibre pcalibre1" id="_ednref2441"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[2441]</span></span></span></a>
 of the seven Churches and the seven lampstands are seven Churches.</p>
 
 <p class="sectiontopic">To Ephesus</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_2">2</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_2">2</p>
 
 <p class="msonormal1"><i class="calibre4">To</i> <i class="calibre4">the</i> <i class="calibre4">angel</i> <i class="calibre4">of</i> <i class="calibre4">the</i> <i class="calibre4">Church</i>
 <i class="calibre4">in</i> <i class="calibre4">Ephesus</i> <i class="calibre4">write:</i></p>
@@ -91,7 +91,7 @@ right hand, he who walks among the seven golden lampstands, says these things:</
 <p class="msonormal1"><sup class="calibre31">2</sup>“I know your works, your toil and perseverance,
 and that you cannot tolerate evil men. You have tested those who call
 themselves apostles although they are not and you have found them to be false. <sup class="calibre31">3</sup>With
-perseverance you have endured much for my Name’s sake; you have<a title="" href="part0000_split_127.html#_edn2442" class="pcalibre pcalibre1" id="_ednref2442"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[2442]</span></span></span></a>
+perseverance you have endured much for my Name’s sake; you have<a title="" href="part0000_split_127.html#_edn2442" class="pcalibre pcalibre1" id="_ednref2442"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[2442]</span></span></span></a>
 not grown weary. <sup class="calibre31">4</sup>Still, I have this against you, that you have left
 your first love. <sup class="calibre31">5</sup>Remember therefore from where you have fallen, and
 repent and do the first works. Otherwise, I am coming to you swiftly<a title="" href="part0000_split_127.html#_edn2443" class="pcalibre pcalibre1" id="_ednref2443"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2443]</span></span></span></a>
@@ -168,14 +168,14 @@ what some call ‘the deep things of Satan,’ to you I say this: I am not putti
 any other burden on you. <sup class="calibre31">25</sup>Nevertheless, hold on to what you have
 with determination until I come. <sup class="calibre31">26</sup>To the one who overcomes and who
 keeps my works to the end, I will give authority over the nations. <sup class="calibre31">27</sup>He
-will rule the nations with a rod of iron, shattering them like clay pots,</span><a title="" href="part0000_split_127.html#_edn2452" class="pcalibre pcalibre1" id="_ednref2452"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre91"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre92">[2452]</span></span></span></span></a><span class="calibre91"> as I also have received of my Father; <a title="" href="part0000_split_127.html#_edn2453" class="pcalibre pcalibre1" id="_ednref2453"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre92">[2453]</span></span></span></a><sup class="calibre31">28</sup>and I will
+will rule the nations with a rod of iron, shattering them like clay pots,</span><a title="" href="part0000_split_127.html#_edn2452" class="pcalibre pcalibre1" id="_ednref2452"><span class="footnote-ref"><span class="calibre91"><span class="footnote-ref"><span class="calibre92">[2452]</span></span></span></span></a><span class="calibre91"> as I also have received of my Father; <a title="" href="part0000_split_127.html#_edn2453" class="pcalibre pcalibre1" id="_ednref2453"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre92">[2453]</span></span></span></a><sup class="calibre31">28</sup>and I will
 give<a title="" href="part0000_split_127.html#_edn2454" class="pcalibre pcalibre1" id="_ednref2454"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre92">[2454]</span></span></span></a>
 him the morning star. <sup class="calibre31">29</sup>Whoever has an ear should listen to what the
 Spirit is saying to the Churches.”</span></p>
 
 <p class="sectiontopic">To Sardis</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_3">3</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_3">3</p>
 
 <p class="msonormal1"><i class="calibre4">And</i> <i class="calibre4">to</i> <i class="calibre4">the</i> <i class="calibre4">angel</i> <i class="calibre4">of</i> <i class="calibre4">the</i>
 <i class="calibre4">Church</i> <i class="calibre4">in</i> <i class="calibre4">Sardis</i> <i class="calibre4">write:</i></p>
@@ -248,7 +248,7 @@ the Churches.”</p>
 
 <p class="sectiontopic">Vision of heavenly worship</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_4">4</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_4">4</p>
 
 <p class="msonormal1">After these things, I looked and saw a door opened in
 heaven. The first voice that I heard was like a trumpet speaking with me. It
@@ -294,7 +294,7 @@ they existed, and were created!”</p>
 
 <p class="sectiontopic">The scroll and the Lamb</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_5">5</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_5">5</p>
 
 <p class="msonormal1">In the right hand of the one who sat on the throne, I saw a
 scroll written inside and outside, sealed shut with seven seals. <sup class="calibre31">2</sup>Then
@@ -360,7 +360,7 @@ the presbyters fell down and expressed adoration.<a title="" href="part0000_spli
 
 <p class="sectiontopic">The first six seals—The four horses<a title="" href="part0000_split_127.html#_edn2477" class="pcalibre pcalibre1" id="_ednref2477"><span class="msoendnotereference"><span class="msoendnotereference"><b class="calibre7"><span class="calibre28">[2477]</span></b></span></span></a></p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_6">6</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_6">6</p>
 
 <p class="msonormal1">I saw that the Lamb opened one of the seven<a title="" href="part0000_split_127.html#_edn2478" class="pcalibre pcalibre1" id="_ednref2478"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2478]</span></span></span></a>
 seals, and I heard one of the four living creatures saying with a voice of
@@ -417,7 +417,7 @@ able to stand?”</p>
 
 <p class="sectiontopic">The 144,000</p>
 
-<p class="style35ptloweredby1ptlinespacingexactly2445pt" id="toc_7">7</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_7">7</p>
 
 <p class="msonormal1">And after this, I saw four angels standing at the four
 corners of the earth. They were holding the four winds<a title="" href="part0000_split_127.html#_edn2491" class="pcalibre pcalibre1" id="_ednref2491"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2491]</span></span></span></a>
@@ -492,7 +492,7 @@ and God will wipe away every tear from their eyes.”</p>
 
 <p class="sectiontopic">The seven trumpets—The golden censer</p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_8">8</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_8">8</p>
 
 <p class="msonormal1">When the Lamb opened the seventh seal, there was silence in
 heaven for about half an hour. <sup class="calibre31">2</sup>I saw the seven angels who stand
@@ -538,7 +538,7 @@ angels are yet to sound!”</p>
 
 <p class="sectiontopic">The fifth trumpet</p>
 
-<p class="style365ptloweredby1ptlinespacingexactly2445pt" id="toc_9">9</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_9">9</p>
 
 <p class="msonormal1">The fifth angel sounded, and I saw a star from heaven which
 had fallen to the earth. The key to the pit of the abyss was given to him. <sup class="calibre31">2</sup>He
@@ -595,7 +595,7 @@ or from their sexual immorality, or from their thefts.</p>
 <p class="sectiontopic">The oath of the mighty angel—The command to eat the
 scroll</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_10">10</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_10">10</p>
 
 <p class="msonormal1">Then I saw another mighty angel coming down from heaven,
 robed with a cloud; and the rainbow was on his head, and his face was like the
@@ -633,7 +633,7 @@ kings.”</p>
 <p class="sectiontopic">The measuring of the temple—The two witnesses (or
 martyrs)</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_11">11</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_11">11</p>
 
 <p class="msonormal1">Then a measuring reed like a staff was given to me. I was
 told,<a title="" href="part0000_split_127.html#_edn2523" class="pcalibre pcalibre1" id="_ednref2523"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2523]</span></span></span></a>
@@ -699,7 +699,7 @@ was seen in his sanctuary! Lightnings, sounds, thunders, an earthquake, and
 great hail followed.<a title="" href="part0000_split_127.html#_edn2541" class="pcalibre pcalibre1" id="_ednref2541"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2541]</span></span></span></a>
 </p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_12">12</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_12">12</p>
 
 <p class="msonormal1">And a great sign was seen in heaven: a woman<a title="" href="part0000_split_127.html#_edn2542" class="pcalibre pcalibre1" id="_ednref2542"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2542]</span></span></span></a>
 clothed with the sun! The moon was under her feet and on her head was a crown
@@ -749,7 +749,7 @@ commandments and hold to the testimony of Jesus.<a title="" href="part0000_split
 
 <p class="sectiontopic">The beast with ten horns and seven heads </p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_13">13</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_13">13</p>
 
 <p class="msonormal1"><a title="" href="part0000_split_127.html#_edn2554" class="pcalibre pcalibre1" id="_ednref2554"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2554]</span></span></span></a>I
 then stood on the seashore and saw a beast coming up out of the sea, having ten
@@ -804,7 +804,7 @@ it is the number of a man. His number is six hundred sixty-six.<a title="" href=
 
 <p class="sectiontopic">The 144,000</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_14">14</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_14">14</p>
 
 <p class="msonormal1"><span class="calibre27">Then I looked, and
 behold, [I saw] the<a title="" href="part0000_split_127.html#_edn2571" class="pcalibre pcalibre1" id="_ednref2571"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre30">[2571]</span></span></span></a>
@@ -876,7 +876,7 @@ hundred stadia.<a title="" href="part0000_split_127.html#_edn2587" class="pcalib
 
 <p class="sectiontopic">The seven angels and their plagues </p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_15">15</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_15">15</p>
 
 <p class="msonormal1">Then I saw another great and marvelous sign in heaven: seven
 angels with the seven last plagues, for in those last plagues God’s wrath is
@@ -915,7 +915,7 @@ plagues of the seven angels would be finished.</p>
 
 <p class="sectiontopic">The seven bowls </p>
 
-<p class="style345ptloweredby15ptlinespacingexactly2445pt" id="toc_16">16</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_16">16</p>
 
 <p class="msonormal1">Then I heard a loud voice out of the sanctuary, saying to
 the seven<a title="" href="part0000_split_127.html#_edn2594" class="pcalibre pcalibre1" id="_ednref2594"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2594]</span></span></span></a>
@@ -983,7 +983,7 @@ hail, because this plague is extremely severe.</p>
 
 <p class="sectiontopic">Babylon the Great and the Beast</p>
 
-<p class="style35ptloweredby1ptlinespacingexactly2445pt" id="toc_17">17</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_17">17</p>
 
 <p class="msonormal1">One of the seven angels who had the seven bowls came and
 spoke with me, saying, “Come here! I will show you the judgment of the great
@@ -1030,7 +1030,7 @@ which reigns over the kings of the earth.”<a title="" href="part0000_split_127
 
 <p class="sectiontopic">The fall of Babylon</p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_18">18</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_18">18</p>
 
 <p class="msonormal1">After these things, I saw another angel coming down out of
 heaven,<a title="" href="part0000_split_127.html#_edn2614" class="pcalibre pcalibre1" id="_ednref2614"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2614]</span></span></span></a>
@@ -1097,7 +1097,7 @@ prophets and of saints, and of all those who have been slain on the earth.”</p
 
 <p class="sectiontopic">The song of victory</p>
 
-<p class="style365ptloweredby1ptlinespacingexactly2445pt" id="toc_19">19</p>
+<p class="chapter-number chapter-number--nudge-1" id="toc_19">19</p>
 
 <p class="msonormal1">After these things, I heard something like<a title="" href="part0000_split_127.html#_edn2623" class="pcalibre pcalibre1" id="_ednref2623"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2623]</span></span></span></a>
 the loud voice of a great multitude in heaven, exclaiming, “Alleluia!<a title="" href="part0000_split_127.html#_edn2624" class="pcalibre pcalibre1" id="_ednref2624"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2624]</span></span></span></a>
@@ -1175,7 +1175,7 @@ gorged themselves with their flesh.</p>
 
 <p class="sectiontopic">The thousand years—The first resurrection</p>
 
-<p class="style375ptloweredby15ptlinespacingexactly2445pt" id="toc_20">20</p>
+<p class="chapter-number chapter-number--nudge-1-5" id="toc_20">20</p>
 
 <p class="msonormal1">Then I saw an angel coming down out of heaven, holding the
 key of the abyss and a great chain in his hand. <sup class="calibre31">2</sup>He seized the
@@ -1228,7 +1228,7 @@ the lake of fire.<a title="" href="part0000_split_127.html#_edn2657" class="pcal
 
 <p class="sectiontopic">The new heaven and new earth </p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_21">21</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_21">21</p>
 
 <p class="msonormal1">Then I saw a new heaven and a new earth: for the first
 heaven and the first earth have passed away, and the sea is no more. <sup class="calibre31">2</sup>I<a title="" href="part0000_split_127.html#_edn2658" class="pcalibre pcalibre1" id="_ednref2658"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2658]</span></span></span></a>
@@ -1252,7 +1252,7 @@ life.<a title="" href="part0000_split_127.html#_edn2665" class="pcalibre pcalibr
 <sup class="calibre31">7</sup>To the one who overcomes, I will give these things. I will be {a}
 God to him, and he will be a son<a title="" href="part0000_split_127.html#_edn2666" class="pcalibre pcalibre1" id="_ednref2666"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2666]</span></span></span></a>
 to me. <sup class="calibre31">8</sup>But as for the cowardly, the unbelieving,<a title="" href="part0000_split_127.html#_edn2667" class="pcalibre pcalibre1" id="_ednref2667"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2667]</span></span></span></a>
-the vile, the murderers, the sexually immoral, those who practice magic,<a title="" href="part0000_split_127.html#_edn2668" class="pcalibre pcalibre1" id="_ednref2668"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[2668]</span></span></span></a>
+the vile, the murderers, the sexually immoral, those who practice magic,<a title="" href="part0000_split_127.html#_edn2668" class="pcalibre pcalibre1" id="_ednref2668"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[2668]</span></span></span></a>
 idolaters, and all liars, their part is in the lake that burns with fire and
 sulfur, which is the second death.”</p>
 
@@ -1303,7 +1303,7 @@ the nations will come, bringing their splendor and tribute.<a title="" href="par
 profane will enter into the city, or anyone who causes an abomination or a lie,
 but only those who are written in the Lamb’s book of life.</span> </p>
 
-<p class="style38ptloweredby2ptlinespacingexactly2445pt" id="toc_22">22</p>
+<p class="chapter-number chapter-number--nudge-2" id="toc_22">22</p>
 
 <p class="msonormal1">The angel<a title="" href="part0000_split_127.html#_edn2682" class="pcalibre pcalibre1" id="_ednref2682"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2682]</span></span></span></a>
 showed me a<a title="" href="part0000_split_127.html#_edn2683" class="pcalibre pcalibre1" id="_ednref2683"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2683]</span></span></span></a>
@@ -1343,7 +1343,7 @@ right, and the holy be holy still.”</p>
 to repay each one according to his work. <sup class="calibre31">13</sup>I am the Alpha and the
 Omega, the First and the Last, the Beginning and the End!<a title="" href="part0000_split_127.html#_edn2690" class="pcalibre pcalibre1" id="_ednref2690"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2690]</span></span></span></a>
 <sup class="calibre31">14</sup>Blessed are those who observe<a title="" href="part0000_split_127.html#_edn2691" class="pcalibre pcalibre1" id="_ednref2691"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2691]</span></span></span></a>
-his commandments,<a title="" href="part0000_split_127.html#_edn2692" class="pcalibre pcalibre1" id="_ednref2692"><span class="stylefootnotereferencelatinitalicblack"><span class="stylefootnotereferencelatinitalicblack"><span class="calibre28">[2692]</span></span></span></a>
+his commandments,<a title="" href="part0000_split_127.html#_edn2692" class="pcalibre pcalibre1" id="_ednref2692"><span class="footnote-ref"><span class="footnote-ref"><span class="calibre28">[2692]</span></span></span></a>
 so that they may have access<a title="" href="part0000_split_127.html#_edn2693" class="pcalibre pcalibre1" id="_ednref2693"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[2693]</span></span></span></a>
 to the tree of life and may enter into the city through the gates. <sup class="calibre31">15</sup>Outside
 are the dogs, the sorcerers, the sexually immoral, the murderers, the idolaters,

--- a/text/part0000_split_074.html
+++ b/text/part0000_split_074.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection33">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_135"><a class="pcalibre pcalibre1" id="_Toc425418864"></a><a class="pcalibre pcalibre1" id="_Toc425418721"></a><a class="pcalibre pcalibre1" id="_Toc425418573"></a><a class="pcalibre pcalibre1" id="_Toc290636428">APPENDIX A: <br class="calibre6"/>
 ACTS 20:28—</a><span class="calibre25">PRESBYTERS AND BISHOPS</span></h1>
 

--- a/text/part0000_split_075.html
+++ b/text/part0000_split_075.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection33">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_136"><a class="pcalibre pcalibre1" id="_Toc425418865"></a><a class="pcalibre pcalibre1" id="_Toc425418722"></a><a class="pcalibre pcalibre1" id="_Toc425418574">Introduction</a></h2>
 
 <p class="msonormal1">The position of historic orthodox catholic Christianity on

--- a/text/part0000_split_076.html
+++ b/text/part0000_split_076.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection33">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_137"><a class="pcalibre pcalibre1" id="_Toc425418866"></a><a class="pcalibre pcalibre1" id="_Toc425418723"></a><a class="pcalibre pcalibre1" id="_Toc425418575">The Letters of St. Ignatius of Antioch</a></h2>
 
 <p class="msonormal1">Ignatius of Antioch was a man who was close in spirit and

--- a/text/part0000_split_077.html
+++ b/text/part0000_split_077.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection33">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_138"><a class="pcalibre pcalibre1" id="_Toc425418867"></a><a class="pcalibre pcalibre1" id="_Toc425418724"></a><a class="pcalibre pcalibre1" id="_Toc425418576">Scriptural Evidence</a></h2>
 
 <p class="msonormal1">When exploring the Scriptural evidence for the truth of the

--- a/text/part0000_split_078.html
+++ b/text/part0000_split_078.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection33">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_139"><a class="pcalibre pcalibre1" id="_Toc425418868"></a><a class="pcalibre pcalibre1" id="_Toc425418725"></a><a class="pcalibre pcalibre1" id="_Toc425418577">St. Clement to the Corinthians</a></h2>
 
 <p class="msonormal1">St. Clement of Rome’s Epistle to the Corinthians, written

--- a/text/part0000_split_079.html
+++ b/text/part0000_split_079.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection33">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_140"><a class="pcalibre pcalibre1" id="_Toc425418869"></a><a class="pcalibre pcalibre1" id="_Toc425418726"></a><a class="pcalibre pcalibre1" id="_Toc425418578">CONCLUSION</a></h2>
 
 <p class="msonormal1">Because the Church is made manifest in the mystery of the

--- a/text/part0000_split_080.html
+++ b/text/part0000_split_080.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection34">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_144"><a class="pcalibre pcalibre1" id="_Toc425418870"></a><a class="pcalibre pcalibre1" id="_Toc425418727"></a><a class="pcalibre pcalibre1" id="_Toc425418579"></a><a class="pcalibre pcalibre1" id="_Toc290636429"><span class="calibre25">APPENDIX B: <br class="calibre6"/>
 MATTH</span>EW 16:18—CHURCH AND APOSTLES</a></h1>
 
@@ -193,32 +193,32 @@ Church in our world, in our town. Beyond that, we have “Churches.”</p>
 <table class="msonormaltable1" border="1" cellspacing="0" cellpadding="0">
  <tr class="calibre114">
   <td width="223" class="calibre115">
-  <p class="stylefranklingothicbook10ptleft"><span class="calibre8">Church (eschatological = pre-eternal or metaeonic =
+  <p class="definition-term"><span class="calibre8">Church (eschatological = pre-eternal or metaeonic =
   total). Could also be called space-time universal (STU).</span></p>
   </td>
   <td width="288" class="calibre116">
-  <p class="stylefranklingothicbook10ptleft1"><span class="calibre8">All
+  <p class="definition-detail"><span class="calibre8">All
   the saints or elect throughout space and time. Also called ‘Catholic Church’
   in the Catechism of the Orthodox Church (COC).</span></p>
   </td>
  </tr>
  <tr class="calibre114">
   <td width="223" class="calibre117">
-  <p class="stylefranklingothicbook10ptleft"><span class="calibre8">Church (catholic</span><span class="calibre8"> = local) (a manifestation of the Church in space and
+  <p class="definition-term"><span class="calibre8">Church (catholic</span><span class="calibre8"> = local) (a manifestation of the Church in space and
   time, by the Holy Spirit. In RC terminology, a ‘particular Church.’</span></p>
   </td>
   <td width="288" class="calibre118">
-  <p class="stylefranklingothicbook10ptleft1"><span class="calibre8">The
+  <p class="definition-detail"><span class="calibre8">The
   saints in a particular city or area, defined by their unity in the Eucharist
   presided by the bishop (now called a diocese or eparchy).</span></p>
   </td>
  </tr>
  <tr class="calibre114">
   <td width="223" class="calibre119">
-  <p class="stylefranklingothicbook10ptleft"><span class="calibre8">Churches (regional, space-universal)</span></p>
+  <p class="definition-term"><span class="calibre8">Churches (regional, space-universal)</span></p>
   </td>
   <td width="288" class="calibre120">
-  <p class="stylefranklingothicbook10ptleft1"><span class="calibre8">The
+  <p class="definition-detail"><span class="calibre8">The
   saints in an area, who do not gather at the same place and under the same
   bishop for one Eucharist.</span></p>
   </td>

--- a/text/part0000_split_081.html
+++ b/text/part0000_split_081.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection34">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_145"><a class="pcalibre pcalibre1" id="_Toc425418872"></a><a class="pcalibre pcalibre1" id="_Toc425418732"></a><a class="pcalibre pcalibre1" id="_Toc425418584"></a><a class="pcalibre pcalibre1" id="_Toc174267643">UNITY IN THE (LOCAL</a><a title="" href="part0000_split_127.html#_edn2740" class="pcalibre pcalibre1" id="_ednref2740"><span class="msoendnotereference"><span class="calibre122"><span class="msoendnotereference"><b class="calibre7"><span class="calibre34"><span class="calibre123">[2740]</span></span></b></span></span></span></a>)
 CATHOLIC CHURCH</h2>
 

--- a/text/part0000_split_082.html
+++ b/text/part0000_split_082.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection34">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_146"><a class="pcalibre pcalibre1" id="_Toc425418873"></a><a class="pcalibre pcalibre1" id="_Toc425418736"></a><a class="pcalibre pcalibre1" id="_Toc425418588"></a><a class="pcalibre pcalibre1" id="_Toc174267647">THE STRUCTURE OF THE CATHOLIC
 CHURCH</a></h2>
 

--- a/text/part0000_split_083.html
+++ b/text/part0000_split_083.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection34">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_147"><a class="pcalibre pcalibre1" id="_Toc425418874"></a><a class="pcalibre pcalibre1" id="_Toc425418746"></a><a class="pcalibre pcalibre1" id="_Toc425418598"></a><a class="pcalibre pcalibre1" id="_Toc174267660">UNITY IN THE ‘UNIVERSAL
 CHURCH’</a></h2>
 

--- a/text/part0000_split_084.html
+++ b/text/part0000_split_084.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection34">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_148"><a class="pcalibre pcalibre1" id="_Toc425418875"></a><a class="pcalibre pcalibre1" id="_Toc425418751"></a><a class="pcalibre pcalibre1" id="_Toc425418603">THE ORTHODOX CHURCH TODAY</a></h2>
 
 <p class="msonormal1">It is then clear that the common idiom ‘(Eastern) Orthodox

--- a/text/part0000_split_085.html
+++ b/text/part0000_split_085.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection35">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_152"><a class="pcalibre pcalibre1" id="_Toc425418876"></a><a class="pcalibre pcalibre1" id="_Toc425418752"></a><a class="pcalibre pcalibre1" id="_Toc425418604"></a><a class="pcalibre pcalibre1" id="_Toc290636430">APPENDIX C: <br class="calibre6"/>
 JOHN 1:1 and 18—JESUS AS “GOD</a>”</h1>
 

--- a/text/part0000_split_086.html
+++ b/text/part0000_split_086.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection35">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_153"><a class="pcalibre pcalibre1" id="_Toc425418878"></a><a class="pcalibre pcalibre1" id="_Toc425418754"></a><a class="pcalibre pcalibre1" id="_Toc425418606">JOHN 1:18—THE “UNIQUELY-BEGOTTEN” SON</a></h2>
 
 <p class="msonormal1">John 1:18 presents a double difficulty. The first aspect is

--- a/text/part0000_split_087.html
+++ b/text/part0000_split_087.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection36">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_157"><a class="pcalibre pcalibre1" id="_Toc425418879"></a><a class="pcalibre pcalibre1" id="_Toc425418755"></a><a class="pcalibre pcalibre1" id="_Toc425418607"></a><a class="pcalibre pcalibre1" id="_Toc290636431">APPENDIX D: <br class="calibre6"/>
 JOHN 15:26—THE FILIOQUE CONTROVERSY</a><a title="" href="part0000_split_127.html#_edn2823" class="pcalibre pcalibre1" id="_ednref2823"><span class="msoendnotereference"><span class="msoendnotereference"><b class="calibre7"><span class="calibre60">[2823]</span></b></span></span></a></h1>
 

--- a/text/part0000_split_088.html
+++ b/text/part0000_split_088.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection36">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_158"><a class="pcalibre pcalibre1" id="_Toc425418881"></a><a class="pcalibre pcalibre1" id="_Toc425418757"></a><a class="pcalibre pcalibre1" id="_Toc425418609"></a><a class="pcalibre pcalibre1" id="_Toc174267788"><span class="calibre25">THE LATIN CREED</span></a></h2>
 
 <p class="msonormal1">The <i class="calibre4">filioque</i> is a modification of the Creed of Nicea-Constantinople (381) which was first introduced in Spain and which was

--- a/text/part0000_split_089.html
+++ b/text/part0000_split_089.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection36">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_159"><a class="pcalibre pcalibre1" id="_Toc425418882"></a><a class="pcalibre pcalibre1" id="_Toc425418758"></a><a class="pcalibre pcalibre1" id="_Toc425418610"></a><a class="pcalibre pcalibre1" id="_Toc174267791"><span class="calibre25">“ONE GOD,” EAST AND WEST</span></a></h2>
 
 <p class="msonormal1">Because Paul Owen writes from a Western perspective, his

--- a/text/part0000_split_090.html
+++ b/text/part0000_split_090.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection36">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_160"><a class="pcalibre pcalibre1" id="_Toc425418883"></a><a class="pcalibre pcalibre1" id="_Toc425418759"></a><a class="pcalibre pcalibre1" id="_Toc425418611"></a><a class="pcalibre pcalibre1" id="_Toc174267792"><span class="calibre25">THE FONT OF DEITY</span></a></h2>
 
 <p class="msonormal1">The article under consideration continues with a clear and

--- a/text/part0000_split_091.html
+++ b/text/part0000_split_091.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection36">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_161"><a class="pcalibre pcalibre1" id="_Toc425418884"></a><a class="pcalibre pcalibre1" id="_Toc425418760"></a><a class="pcalibre pcalibre1" id="_Toc425418612"></a><a class="pcalibre pcalibre1" id="_Toc174267793"><span lang="EN" class="calibre25">THE LATIN FILIOQUE: INTENT AND CONCERNS</span></a></h2>
 
 <p class="msonormal1"><span lang="EN">Let us consider point (2), “</span>that the

--- a/text/part0000_split_092.html
+++ b/text/part0000_split_092.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection36">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_162"><a class="pcalibre pcalibre1" id="_Toc425418885"></a><a class="pcalibre pcalibre1" id="_Toc425418761"></a><a class="pcalibre pcalibre1" id="_Toc425418613"></a><a class="pcalibre pcalibre1" id="_Toc174267794"><span class="calibre25">FROM THE FATHER THROUGH THE SON?</span></a></h2>
 
 <p class="msonormal1">We now arrive at an expression that is acceptable on both

--- a/text/part0000_split_093.html
+++ b/text/part0000_split_093.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection36">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_163"><a class="pcalibre pcalibre1" id="_Toc425418886"></a><a class="pcalibre pcalibre1" id="_Toc425418762"></a><a class="pcalibre pcalibre1" id="_Toc425418614"></a><a class="pcalibre pcalibre1" id="_Toc174267795"><span class="calibre25">REVISIONIST THEOLOGY?</span></a></h2>
 
 <p class="msonormal1">There is another valid reason for which Orthodox are loath

--- a/text/part0000_split_094.html
+++ b/text/part0000_split_094.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection36">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_164"><a class="pcalibre pcalibre1" id="_Toc425418887"></a><a class="pcalibre pcalibre1" id="_Toc425418763"></a><a class="pcalibre pcalibre1" id="_Toc425418615">THE TRINITY</a></h2>
 
 <p class="msonormal1">Perhaps one reason for the mystery and abstract complexity

--- a/text/part0000_split_095.html
+++ b/text/part0000_split_095.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection36">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_165"><a class="pcalibre pcalibre1" id="_Toc425418888"></a><a class="pcalibre pcalibre1" id="_Toc425418764"></a><a class="pcalibre pcalibre1" id="_Toc425418616"></a><a class="pcalibre pcalibre1" id="_Toc174267797"><span class="calibre25">THE FEAR OF ARIANISM</span></a></h2>
 
 <p class="msonormal1">It may be useful to mention that the ‘shadow of Arianism’—and the fear thereof—may be more of a factor than is often realized. For various

--- a/text/part0000_split_096.html
+++ b/text/part0000_split_096.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection36">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_166"><a class="pcalibre pcalibre1" id="_Toc425418889"></a><a class="pcalibre pcalibre1" id="_Toc425418765"></a><a class="pcalibre pcalibre1" id="_Toc425418617"></a><a class="pcalibre pcalibre1" id="_Toc174267798"><span class="calibre25">IN SUMMARY</span></a></h2>
 
 <p class="msonormal1">Many leading Orthodox theologians agree that a statement of

--- a/text/part0000_split_097.html
+++ b/text/part0000_split_097.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_172"><a class="pcalibre pcalibre1" id="_Toc425418890"></a><a class="pcalibre pcalibre1" id="_Toc425418766"></a><a class="pcalibre pcalibre1" id="_Toc425418618"></a><a class="pcalibre pcalibre1" id="_Toc290636432">APPENDIX E:<br class="calibre6"/>
 MARK 6:3</a><span class="calibre25">—THE ‘BROTHERS’ </span>OF THE
 LORD</h1>

--- a/text/part0000_split_098.html
+++ b/text/part0000_split_098.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_173"><a class="pcalibre pcalibre1" id="_Toc425418891"></a><a class="pcalibre pcalibre1" id="_Toc425418767"></a><a class="pcalibre pcalibre1" id="_Toc425418619">THREE VIEWS</a></h2>
 
 <p class="msonormal1">Three theories have been presented to account for the

--- a/text/part0000_split_099.html
+++ b/text/part0000_split_099.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_174"><a class="pcalibre pcalibre1" id="_Toc425418892"></a><a class="pcalibre pcalibre1" id="_Toc425418768"></a><a class="pcalibre pcalibre1" id="_Toc425418620">DOGMAS AND CONVICTIONS</a></h2>
 
 <p class="msonormal1">From an Eastern Orthodox perspective, it is important to

--- a/text/part0000_split_100.html
+++ b/text/part0000_split_100.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_175"><a class="pcalibre pcalibre1" id="_Toc425418893"></a><a class="pcalibre pcalibre1" id="_Toc425418769"></a><a class="pcalibre pcalibre1" id="_Toc425418621">THE NEW TESTAMENT TEXTS</a></h2>
 
 <p class="msonormal1">This exegesis by a native Greek speaker and Biblical exegete

--- a/text/part0000_split_101.html
+++ b/text/part0000_split_101.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_176"><a class="pcalibre pcalibre1" id="_Toc425418894"></a><a class="pcalibre pcalibre1" id="_Toc425418770"></a><a class="pcalibre pcalibre1" id="_Toc425418622">POSITIVE EVIDENCE AND INDICATIONS</a></h2>
 
 <p class="msonormal1">Mark 6:3, which mentions the <i class="calibre4">adelphoi</i> of Jesus, may

--- a/text/part0000_split_102.html
+++ b/text/part0000_split_102.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_177"><a class="pcalibre pcalibre1" id="_Toc425418895"></a><a class="pcalibre pcalibre1" id="_Toc425418771"></a><a class="pcalibre pcalibre1" id="_Toc425418623">THEOLOGY AND TYPOLOGY</a></h2>
 
 <p class="msonormal1">In addition to the historic-textual data discussed above,

--- a/text/part0000_split_103.html
+++ b/text/part0000_split_103.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_178"><a class="pcalibre pcalibre1" id="_Toc425418896"></a><a class="pcalibre pcalibre1" id="_Toc425418772"></a><a class="pcalibre pcalibre1" id="_Toc425418624">EARLY CHRISTIAN WITNESSES</a></h2>
 
 <p class="msonormal1">Writing in the middle of the second century, Origen was

--- a/text/part0000_split_104.html
+++ b/text/part0000_split_104.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_179"><a class="pcalibre pcalibre1" id="_Toc425418897"></a><a class="pcalibre pcalibre1" id="_Toc425418773"></a><a class="pcalibre pcalibre1" id="_Toc425418625">INVESTIGATING JAMES AND ‘THE OTHER MARY:’ A WORD ABOUT THE
 JEROMIAN VIEW</a></h2>
 

--- a/text/part0000_split_105.html
+++ b/text/part0000_split_105.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_180"><a class="pcalibre pcalibre1" id="_Toc425418898"></a><a class="pcalibre pcalibre1" id="_Toc425418774"></a><a class="pcalibre pcalibre1" id="_Toc425418626">SUMMARY</a></h2>
 
 <p class="msonormal1">The same Fathers who discerned the canon of the New

--- a/text/part0000_split_106.html
+++ b/text/part0000_split_106.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_182"><a class="pcalibre pcalibre1" id="_Toc425418899"></a><a class="pcalibre pcalibre1" id="_Toc425418775"></a><a class="pcalibre pcalibre1" id="_Toc425418627"></a><a class="pcalibre pcalibre1" id="_Toc290636433"><span class="calibre25">APPENDIX F:<br class="calibre6"/>
 MARK 16:9-20 - THE MYSTERY OF MARK’S ALTERNATE ENDINGS</span></a><a title="" href="part0000_split_127.html#_edn2894" class="pcalibre pcalibre1" id="_ednref2894"><span class="msoendnotereference"><span class="msoendnotereference"><b class="calibre7"><span class="calibre60">[2894]</span></b></span></span></a></h1>
 

--- a/text/part0000_split_107.html
+++ b/text/part0000_split_107.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_183"><a class="pcalibre pcalibre1" id="_Toc425418900"></a><a class="pcalibre pcalibre1" id="_Toc425418776"></a><a class="pcalibre pcalibre1" id="_Toc425418628">INTERNAL EVIDENCE</a></h2>
 
 <p class="msonormal1">Besides the manuscript evidence, some scholars appeal to

--- a/text/part0000_split_108.html
+++ b/text/part0000_split_108.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_184"><a class="pcalibre pcalibre1" id="_Toc425418901"></a><a class="pcalibre pcalibre1" id="_Toc425418777"></a><a class="pcalibre pcalibre1" id="_Toc425418629">A POSSIBLE AUTHOR FOR MARK’S ENDING</a></h2>
 
 <p class="msonormal1">There is another possibility to explain the abrupt ending in

--- a/text/part0000_split_109.html
+++ b/text/part0000_split_109.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_185"><a class="pcalibre pcalibre1" id="_Toc425418902"></a><a class="pcalibre pcalibre1" id="_Toc425418778"></a><a class="pcalibre pcalibre1" id="_Toc425418630">EXTERNAL / MANUSCRIPT EVIDENCE</a></h2>
 
 <p class="msonormal1">We now turn to the external evidence. Over 1,500 Greek

--- a/text/part0000_split_110.html
+++ b/text/part0000_split_110.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_186"><a class="pcalibre pcalibre1" id="_Toc425418903"></a><a class="pcalibre pcalibre1" id="_Toc425418779"></a><a class="pcalibre pcalibre1" id="_Toc425418631">EARLY CHURCH WRITERS</a></h2>
 
 <p class="msonormal1">Furthermore, evidence that is older than Vaticanus and

--- a/text/part0000_split_111.html
+++ b/text/part0000_split_111.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_187"><a class="pcalibre pcalibre1" id="_Toc425418904"></a><a class="pcalibre pcalibre1" id="_Toc425418780"></a><a class="pcalibre pcalibre1" id="_Toc425418632">THE ABRUPT AND SHORTER ENDING</a></h2>
 
 <p class="msonormal1">We could also consider additional evidence for the ending at

--- a/text/part0000_split_112.html
+++ b/text/part0000_split_112.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_188"><a class="pcalibre pcalibre1" id="_Toc425418905"></a><a class="pcalibre pcalibre1" id="_Toc425418781"></a><a class="pcalibre pcalibre1" id="_Toc425418633">THE CASE OF CLEMENT AND ORIGEN</a></h2>
 
 <p class="msonormal1">We now turn to evidence against the inclusion of Mark

--- a/text/part0000_split_113.html
+++ b/text/part0000_split_113.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_189"><a class="pcalibre pcalibre1" id="_Toc425418906"></a><a class="pcalibre pcalibre1" id="_Toc425418782"></a><a class="pcalibre pcalibre1" id="_Toc425418634"><span class="calibre25">ETHIOPIC VERSIONS</span></a></h2>
 
 <p class="msonormal1">Regarding the Ethiopic version, it should be noted that some

--- a/text/part0000_split_114.html
+++ b/text/part0000_split_114.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_190"><a class="pcalibre pcalibre1" id="_Toc425418907"></a><a class="pcalibre pcalibre1" id="_Toc425418783"></a><a class="pcalibre pcalibre1" id="_Toc425418635">POSSIBLE TRANSMISSION STREAM</a></h2>
 
 <p class="msonormal1"><span>When we view all of this external

--- a/text/part0000_split_115.html
+++ b/text/part0000_split_115.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection37">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_191"><a class="pcalibre pcalibre1" id="_Toc425418908"></a><a class="pcalibre pcalibre1" id="_Toc425418784"></a><a class="pcalibre pcalibre1" id="_Toc425418636">ECCLESIATICAL USE</a></h2>
 
 <p class="msonormal1"><span>Besides all the data from

--- a/text/part0000_split_116.html
+++ b/text/part0000_split_116.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection38">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_195"><a class="pcalibre pcalibre1" id="_Toc425418909"></a><a class="pcalibre pcalibre1" id="_Toc425418785"></a><a class="pcalibre pcalibre1" id="_Toc425418637"></a><a class="pcalibre pcalibre1" id="_Toc290636434">APPENDIX G:<br class="calibre6"/>
 LUKE 3:36 – THE SECOND CAINAN</a> CONTROVERSY<a title="" href="part0000_split_127.html#_edn2900" class="pcalibre pcalibre1" id="_ednref2900"><span class="msoendnotereference"><span class="msoendnotereference"><b class="calibre7"><span class="calibre60">[2900]</span></b></span></span></a></h1>
 

--- a/text/part0000_split_117.html
+++ b/text/part0000_split_117.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection38">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_196"><a class="pcalibre pcalibre1" id="_Toc425418910"></a><a class="pcalibre pcalibre1" id="_Toc425418786"></a><a class="pcalibre pcalibre1" id="_Toc425418638">DID THE ORIGINAL LUKE INCLUDE THE SECOND CAINAN?</a></h2>
 
 <p class="msonormal1"><b class="calibre7">The first hypothesis to be tested is that Luke did not

--- a/text/part0000_split_118.html
+++ b/text/part0000_split_118.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection38">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_197"><a class="pcalibre pcalibre1" id="_Toc425418911"></a><a class="pcalibre pcalibre1" id="_Toc425418787"></a><a class="pcalibre pcalibre1" id="_Toc425418639">THE RELATIONSHIP BETWEEN LUKE AND THE LXX</a></h2>
 
 <p class="msonormal1">In short, the question is, “did Luke follow the LXX or did

--- a/text/part0000_split_119.html
+++ b/text/part0000_split_119.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection38">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_198"><a class="pcalibre pcalibre1" id="_Toc425418912"></a><a class="pcalibre pcalibre1" id="_Toc425418788"></a><a class="pcalibre pcalibre1" id="_Toc425418640">TWO STREAMS OF TRADITION?</a></h2>
 
 <p class="msonormal1">In view of the above, another theory to be suggested is that

--- a/text/part0000_split_120.html
+++ b/text/part0000_split_120.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection38">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_199"><a class="pcalibre pcalibre1" id="_Toc425418913"></a><a class="pcalibre pcalibre1" id="_Toc425418789"></a><a class="pcalibre pcalibre1" id="_Toc425418641">UNDERSTANDING THE PATTERNS</a></h2>
 
 <p class="msonormal1">Why did the Masoretes apply a formula of 100 year reduction

--- a/text/part0000_split_121.html
+++ b/text/part0000_split_121.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection38">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_200"><a class="pcalibre pcalibre1" id="_Toc425418914"></a><a class="pcalibre pcalibre1" id="_Toc425418790"></a><a class="pcalibre pcalibre1" id="_Toc425418642"><span class="calibre25">ABRAHAM’S GENERATION</span></a></h2>
 
 <p class="msonormal1">Throughout history Abraham was referred to as the 10<sup class="calibre31">th</sup>

--- a/text/part0000_split_122.html
+++ b/text/part0000_split_122.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection38">
+<div class="section">
 <h2 class="section-heading" id="calibre_pb_201"><a class="pcalibre pcalibre1" id="_Toc425418915"></a><a class="pcalibre pcalibre1" id="_Toc425418791"></a><a class="pcalibre pcalibre1" id="_Toc425418643">SUMMARY</a></h2>
 
 <p class="msonormal1">The question of the second Cainan begins with Luke 3:36 but

--- a/text/part0000_split_123.html
+++ b/text/part0000_split_123.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection39">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_205"><a class="pcalibre pcalibre1" id="_Toc425418916"></a><a class="pcalibre pcalibre1" id="_Toc425418792"></a><a class="pcalibre pcalibre1" id="_Toc425418644"></a><a class="pcalibre pcalibre1" id="_Toc290636391">ABBREVIATIONS AND CODES</a></h1>
 
 <table class="msonormaltable1" border="1" cellspacing="0" cellpadding="0">

--- a/text/part0000_split_124.html
+++ b/text/part0000_split_124.html
@@ -7,7 +7,7 @@
 <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
 </head>
   <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="wordsection39">
+<div class="section">
 <h1 class="calibre9" id="calibre_pb_207"><a class="pcalibre pcalibre1" id="_Toc425418917"></a><a class="pcalibre pcalibre1" id="_Toc425418793"></a><a class="pcalibre pcalibre1" id="_Toc425418645"><span lang="FR">ENDNOTES</span></a></h1>
 
 <p class="msonormal15"><span lang="FR"> </span></p>


### PR DESCRIPTION
## Summary
- replace the legacy `wordsection*` wrapper definitions with a reusable `.section` class that adds page breaks with `break-before`
- retire the exported `.style…` classes by introducing semantic helpers for chapter numbers, footnote references, and glossary table entries
- update all XHTML chapter files to use the new semantic classes and remove obsolete references

## Testing
- rg "wordsection" text
- rg 'class="style' text

------
https://chatgpt.com/codex/tasks/task_e_68d7e9b1e4ac8329b6096717bca19cdb