### PR TITLE
Refactor PURPOSE section markup to match updated CSS

### DIFF
--- a/text/part0000_split_006.html
+++ b/text/part0000_split_006.html
@@ -2,115 +2,35 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>Matthew</title>
-    
-  <link href="../stylesheet.css" rel="stylesheet" type="text/css"/>
-<link href="../page_styles.css" rel="stylesheet" type="text/css"/>
-</head>
-  <body lang="EN-US" link="blue" vlink="purple" class="calibre">
-<div class="section">
-<h2 class="section-heading" id="calibre_pb_12"><a class="pcalibre pcalibre1" id="_Toc425418798"></a><a class="pcalibre pcalibre1" id="_Toc425418650"></a><a class="pcalibre pcalibre1" id="_Toc425418502"><span class="calibre25">PURPOSE</span></a></h2>
+    <link href="../stylesheet.css" rel="stylesheet" type="text/css"/>
+    <link href="../page_styles.css" rel="stylesheet" type="text/css"/>
+  </head>
+  <body>
+    <section>
+      <h2 class="section-heading" id="calibre_pb_12">PURPOSE</h2>
+      <p class="p noindent">The EOB New Testament was prepared for personal study and liturgical use in English-speaking Orthodox Christian communities. Its format and font are designed to make both activities accessible and rewarding. Every attempt has been made to offer an accurate and scholarly translation of the Greek text, free of the theological bias that has affected most other translations of the New Testament, including the NIV (2 Thess. 2:15) and NAB (Matt. 5:32).</p>
+      <p class="p">Another intention of this translation is to foster interest in learning the Greek language (biblical, patristic and modern), which is why many footnotes make reference to the underlying Greek vocabulary.</p>
+      <p class="p">The purpose of this edition is also to make the reader aware of possible textual variants by footnoting all significant instances where the Patriarchal Text (PT) may not agree with the Textus Receptus (TR), the Majority Text (MT) or the Critical Text (CT). In several instances, the footnotes will provide references to specific manuscripts.</p>
+      <p class="p">Until the publication of the EOB, the King James and New King James versions have been the preferred translations, partly because they are based on the <strong>Textus Receptus</strong> (TR) which is a Byzantine-type text that is close to the normative ecclesiastical text of the Greek-speaking Orthodox Churches.</p>
 
-<p class="msonormal1">The EOB New Testament was prepared for personal study and
-liturgical use in English-speaking Orthodox Christian communities. Its format
-and font are designed to make both activities accessible and rewarding. Every
-attempt has been made to offer an accurate and scholarly translation of the
-Greek text, free of the theological bias that has affected most other
-translations of the New Testament, including the NIV (2 Thess. 2:15) and NAB
-(Matt. 5:32).</p>
+      <div class="spacer"></div>
 
-<p class="msonormal1">Another intention of this translation is to foster interest
-in learning the Greek language (biblical, patristic and modern), which is why
-many footnotes make reference to the underlying Greek vocabulary.</p>
+      <div class="quote">
+        <p class="p noindent">The <strong>Textus Receptus</strong> (Latin: “received text”) is the name subsequently given to the succession of printed Greek texts of the New Testament which constituted the translation base for Luther’s original German Bible. The TR was also used for the translation of the New Testament into English by William Tyndale, for the King James Version, and for most other Reformation-era New Testament translations throughout Western and Central Europe.</p>
+        <p class="p">This series of printed texts originated with the first printed Greek New Testament to be published. This project was undertaken in Basel in 1516 by Desiderius Erasmus, a Dutch Roman Catholic scholar and humanist. This first TR was assembled on the basis of six manuscripts which put together did not actually contain the entirety of the New Testament. For this reason, the Erasmus TR is especially problematic for the book of Revelation. Although based mainly on late manuscripts of the Byzantine text-type, Erasmus’ edition differed markedly from the classic form of that text. In 1,838 places (1,005 translatable) Textus Receptus differs from the Byzantine text-type (Majority Text).</p>
+        <p class="p">The TR was subsequently revised by Robert Estienne (known as Stefanus) (1503-1559), a printer from Paris, who edited the Greek New Testament four times: in 1546, 1549, 1550, and 1551.</p>
+        <p class="p">The origin of the term “Textus Receptus” comes from the publisher’s preface to the 1633 edition produced by the Elzevir brothers in Amsterdam.</p>
+      </div>
 
-<p class="msonormal1">The purpose of this edition is also to make the reader aware
-of possible textual variants by footnoting all significant instances where the
-Patriarchal Text (PT) may not agree with the Textus Receptus (TR), the Majority
-Text (MT) or the Critical Text (CT). In several instances, the footnotes will
-provide references to specific manuscripts.</p>
+      <div class="spacer"></div>
 
-<p class="msonormal1">Until the publication of the EOB, the King James and New
-King James versions have been the preferred translations, partly because they
-are based on the <b class="calibre7">Textus Receptus</b> (TR) which is a Byzantine-type text
-that is close to the normative ecclesiastical text of the Greek-speaking
-Orthodox Churches.</p>
+      <p class="p">Several versions of the <strong>King James Version</strong> (KJV) currently exist, but all suffer from the imperfections of the Textus Receptus prepared by Erasmus (1522, third edition) from a small number of manuscripts and revised by Stephanus (1550). Moreover, the Old Testament of the KJV is mostly based on the <strong>Masoretic text</strong> and fails to include significant Septuagintal variants. Also, even though the original 1611 edition of the KJV included the so-called ‘apocryphal’ books, these were removed in subsequent editions, thus preventing proper ecclesiastical use in an Orthodox context.</p>
+    </section>
 
-<p class="msonormal1"> </p>
-
-<div class="calibre26">
-
-<p class="boxparcxspfirst"><span class="calibre27">The <b class="calibre7">Textus Receptus</b> (Latin: “received
-text”) is the name subsequently given to the succession of printed Greek texts
-of the New Testament which constituted the translation base for Luther’s
-original German Bible. The TR was also used for the translation of the New Testament
-into English by William Tyndale, for the King James Version, and for most other
-Reformation-era New Testament translations throughout Western and Central
-Europe.</span></p>
-
-<p class="boxparcxspmiddle">This
-series of printed texts originated with the first printed Greek New Testament
-to be published. This project was undertaken in Basel in 1516 by Desiderius
-Erasmus, a Dutch Roman Catholic scholar and humanist. This first TR was
-assembled on the basis of six manuscripts which put together did not actually
-contain the entirety of the New Testament. For this reason, the Erasmus TR is
-especially problematic for the book of Revelation. Although based mainly on
-late manuscripts of the Byzantine text-type, Erasmus’ edition differed markedly
-from the classic form of that text. In 1,838 places (1,005 translatable) Textus
-Receptus differs from the Byzantine text-type (Majority Text).</p>
-
-<p class="boxparcxspmiddle"><br class="calibre6"/>
-The TR was subsequently revised by Robert Estienne (known as Stefanus)
-(1503-1559), a printer from Paris, who edited the Greek New Testament four
-times: in 1546, 1549, 1550, and 1551.</p>
-
-<p class="boxparcxsplast"><br class="calibre6"/>
-The origin of the term “Textus Receptus” comes from the publisher’s preface to
-the 1633 edition produced by the Elzevir brothers in Amsterdam.</p>
-
-</div>
-
-<p class="msonormal1"> </p>
-
-<p class="msonormal1">Several versions of the <b class="calibre7">King James Version</b> (KJV) currently
-exist, but all suffer from the imperfections of the Textus Receptus prepared by
-Erasmus (1522, third edition) from a small number of manuscripts and revised by
-Stephanus (1550). Moreover, the Old Testament of the KJV is mostly based on the
-<b class="calibre7">Masoretic text</b> and fails to include significant Septuagintal variants.
-Also, even though the original 1611 edition of the KJV included the so-called
-‘apocryphal’ books, these were removed in subsequent editions, thus preventing
-proper ecclesiastical use in an Orthodox context.</p>
-
-</div>
-
-<span class="calibre5"><br clear="all" class="calibre10"/>
-</span>
-
-<div class="section">
-
-<p class="msonormal1"><a title="" href="part0000_split_124.html#_edn1" class="pcalibre pcalibre1" id="_ednref1"><span class="msoendnotereference"><span class="msoendnotereference"><span class="calibre28">[1]</span></span></span></a></p>
-
-<p class="msonormal1">In North America, most parishes of the Orthodox Church in
-America and of the Antiochian Archdiocese still use Elizabethan English in the
-liturgy, in which case the KJV does provide linguistic continuity, although at
-the expense of universal accessibility. In practice however, it seems that the
-majority of Orthodox parishes read the Scriptures in formal but contemporary
-English, often from the <b class="calibre7">New King James Version</b> (NKJV). This particular
-modern-language translation is also based on the Textus Receptus and follows
-the formal-equivalency approach and general style of the KJV. In addition, the
-NKJV provides comprehensive footnotes which discuss significant variant
-readings. One major limitation with the NKJV is that it is a commercial,
-copyrighted translation which lies completely outside the control of the
-Orthodox Christian community. Moreover, certain issues of translation and
-terminology (discussed below) also called for revisions within an Orthodox
-context.</p>
-
-<p class="msonormal1">The <b class="calibre7">EOB (Eastern/Greek Orthodox Bible or Holy Bible of
-the [Eastern/Greek] Orthodox Churches) </b>addresses these limitations, both in
-the Old and New Testaments. A limited copyright (see inner front page) is held
-by the publisher but the text is non-commercial, held within the Orthodox
-community and managed as a collaborative project, both for revisions and for
-liturgical use. Moreover, Orthodox Christians are invited to submit their
-suggestions so that the published text may be regularly updated and improved.</p>
-
-</div>
-
-</body></html>
+    <section>
+      <p class="p noindent"><a class="noteref" href="part0000_split_124.html#_edn1" id="_ednref1">[1]</a></p>
+      <p class="p">In North America, most parishes of the Orthodox Church in America and of the Antiochian Archdiocese still use Elizabethan English in the liturgy, in which case the KJV does provide linguistic continuity, although at the expense of universal accessibility. In practice however, it seems that the majority of Orthodox parishes read the Scriptures in formal but contemporary English, often from the <strong>New King James Version</strong> (NKJV). This particular modern-language translation is also based on the Textus Receptus and follows the formal-equivalency approach and general style of the KJV. In addition, the NKJV provides comprehensive footnotes which discuss significant variant readings. One major limitation with the NKJV is that it is a commercial, copyrighted translation which lies completely outside the control of the Orthodox Christian community. Moreover, certain issues of translation and terminology (discussed below) also called for revisions within an Orthodox context.</p>
+      <p class="p">The <strong>EOB (Eastern/Greek Orthodox Bible or Holy Bible of the [Eastern/Greek] Orthodox Churches)</strong> addresses these limitations, both in the Old and New Testaments. A limited copyright (see inner front page) is held by the publisher but the text is non-commercial, held within the Orthodox community and managed as a collaborative project, both for revisions and for liturgical use. Moreover, Orthodox Christians are invited to submit their suggestions so that the published text may be regularly updated and improved.</p>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- rebuild the PURPOSE section markup in `text/part0000_split_006.html` using the streamlined CSS classes
- replace legacy Calibre spans and box wrappers with semantic paragraphs, quote blocks, and spacers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e59f020ad083298dcdb0cb3c5f7731